### PR TITLE
Enhance eGolf data mapping for flat format

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -368,7 +368,7 @@ class Connector(BaseConnector):
             return {}
         return result
 
-    def _map_dataset(self, vin: str, dataset: Dataset, payload: dict) -> None:
+    def _map_dataset(self, vin: str, dataset: Dataset, payload: Optional[dict] = None) -> None:
         """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only)."""
         garage: Garage = self.car_connectivity.garage
         vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)  # pyright: ignore[reportAssignmentType]
@@ -380,7 +380,7 @@ class Connector(BaseConnector):
         # The eGolf delivers a flat Data array (no dotted field names) instead
         # of the nested report structure used by ID.x vehicles. Detect it here
         # and hand off to the dedicated mapper; skip the ID.x path entirely.
-        flat_fields = self._extract_flat_fields(payload)
+        flat_fields = self._extract_flat_fields(payload) if payload is not None else {}
         if flat_fields:
             LOG.debug('Detected flat (eGolf) dataset format for %s', vin)
             self._map_flat_dataset(vehicle, garage, vin, flat_fields, captured_at)

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta, timezone
 
 from carconnectivity.errors import AuthenticationError, RetrievalError, TooManyRequestsError
 from carconnectivity.util import config_remove_credentials
-from carconnectivity.units import Length, Power, Temperature
+from carconnectivity.units import Length, Power, Speed, Temperature
 from carconnectivity.attributes import DurationAttribute, EnumAttribute
 from carconnectivity.vehicle import GenericVehicle
 from carconnectivity.drive import ElectricDrive, GenericDrive
@@ -40,11 +40,13 @@ from carconnectivity_connectors.vw_eu_data_act.client import (
     DEFAULT_BRAND, DEFAULT_COUNTRY, DEFAULT_LANGUAGE, NO_CONTENT_SUFFIX,
     ApiError, AuthError, EudaApiClient,
 )
-from carconnectivity_connectors.vw_eu_data_act.dataset import Dataset, parse_timestamp, resolve_distance_unit
+from carconnectivity_connectors.vw_eu_data_act.dataset import (
+    Dataset, parse_timestamp, resolve_charge_rate_unit, resolve_distance_unit,
+)
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional
+    from typing import Any, Dict, List, Optional, Tuple
     from carconnectivity.carconnectivity import CarConnectivity
     from carconnectivity.garage import Garage
 
@@ -80,18 +82,36 @@ CHARGE_STATE_MAPPING: "Dict[str, Charging.ChargingState]" = {
     'CHARGE_STATE_CHARGING_ERROR': Charging.ChargingState.ERROR,
 }
 
-# Map eGolf flat charging_state strings to CarConnectivity enums.
-FLAT_CHARGE_STATE_MAPPING: "Dict[str, Charging.ChargingState]" = {
-    'charging':     Charging.ChargingState.CHARGING,
-    'not_charging': Charging.ChargingState.OFF,
-    'complete':     Charging.ChargingState.CONSERVATION,
-}
-
 WINDOW_HEATING_MAPPING: "Dict[str, WindowHeatings.HeatingState]" = {
     'WINDOW_HEATING_STATE_OFF': WindowHeatings.HeatingState.OFF,
     'WINDOW_HEATING_STATE_ON': WindowHeatings.HeatingState.ON,
     'WINDOW_HEATING_STATE_INVALID': WindowHeatings.HeatingState.INVALID,
 }
+
+# Map the portal's charge-type enum (what the car is plugged into) to the
+# generic CarConnectivity charging-type enum.
+CHARGE_TYPE_MAPPING: "Dict[str, Charging.ChargingType]" = {
+    'CHARGE_TYPE_INVALID': Charging.ChargingType.INVALID,
+    'CHARGE_TYPE_OFF': Charging.ChargingType.OFF,
+    'CHARGE_TYPE_AC': Charging.ChargingType.AC,
+    'CHARGE_TYPE_DC': Charging.ChargingType.DC,
+}
+
+
+def _charge_rate_per_hour(value: float, unit_enum) -> "Tuple[float, Speed]":
+    """Normalise a portal charge rate to a per-hour speed.
+
+    The portal reports the charge rate as range gained over time; the companion
+    ``charge_rate_unit`` enum says whether that is km or miles and per hour or
+    per minute. The native SpeedAttribute is per-hour only, so per-minute rates
+    are scaled by 60. Defaults to km/h when the unit is absent/unrecognised.
+    """
+    resolved = resolve_charge_rate_unit(unit_enum)
+    distance, per_minute = resolved if resolved is not None else ("km", False)
+    if per_minute:
+        value = value * 60
+    return value, Speed.MPH if distance == "mi" else Speed.KMH
+
 
 def _filename_timestamp(name: str) -> "Optional[datetime]":
     """Parse a YYYYMMDDhhmmss segment from a dataset filename.
@@ -120,6 +140,24 @@ def _created_on(entry: dict) -> "Optional[datetime]":
     return parsed if parsed is not None else _filename_timestamp(entry.get("name", ""))
 
 
+# --- Known mapped fields for detecting unmapped sensors --------------------
+KNOWN_MAPPED_FIELDS: set[str] = {
+    'mileage.value',
+    'mileage.unit',
+    'mileage.state',
+    'locked',
+    'window_heating_state',
+    'battery_state_report.soc',
+    'range',
+    'min_temperature',
+    'max_temperature',
+    'battery_state_report.charge_power',
+    'charging_state_report.current_charge_state',
+    'settings.target_soc',
+    'car_captured_time',
+}
+
+
 class Connector(BaseConnector):
     """Read-only connector for the Volkswagen EU Data Act portal."""
 
@@ -137,6 +175,16 @@ class Connector(BaseConnector):
         self._stop_event = threading.Event()
         # Per-VIN data-request identifier, resolved lazily from the metadata endpoint.
         self._identifiers: Dict[str, str] = {}
+        # Per-VIN name of the newest data-bearing dataset already downloaded and
+        # mapped, so intervals that produced only a "no content" zip don't trigger
+        # a redundant re-download of the same dataset.
+        self._last_dataset: Dict[str, str] = {}
+        # Tracks whether the initial bootstrap (download all zips, build cache) has run per VIN.
+        self._bootstrapped: set[str] = set()
+        # Merged dataset per VIN tracking the latest value per field across all downloaded zips.
+        self._merged_datasets: Dict[str, Dataset] = {}
+        # Set of field names already observed per VIN (used to detect new/unmapped sensors).
+        self._observed_fields: Dict[str, set] = {}
 
         self.connection_state: EnumAttribute[ConnectionState] = EnumAttribute(
             name="connection_state", parent=self, value_type=ConnectionState,
@@ -236,6 +284,13 @@ class Connector(BaseConnector):
                 self.connection_state._set_value(value=ConnectionState.ERROR)  # pylint: disable=protected-access
                 self._stop_event.wait(900)
             except (RetrievalError, ApiError) as err:
+                # A failed poll (transient network/DNS blip, a stale data-request
+                # identifier, etc.) should recover on the next short cycle rather
+                # than freezing the data for the full ~15-min cadence: retry within
+                # ~1 min. The next successful update reschedules to the normal
+                # cadence via _reschedule(). (HA f129ebc)
+                interval = RETRY_INTERVAL.total_seconds()
+                self.interval._set_value(RETRY_INTERVAL)  # pylint: disable=protected-access
                 LOG.error('Retrieval error during update (%s). Will try again after %ss', str(err), interval)
                 self.connection_state._set_value(value=ConnectionState.ERROR)  # pylint: disable=protected-access
                 self._stop_event.wait(interval)
@@ -314,185 +369,241 @@ class Connector(BaseConnector):
         # enabled attributes are never announced and HA entities stay "unavailable".
         self.car_connectivity.transaction_end()
 
+    def _refresh_identifier(self, vin: str) -> "Optional[str]":
+        """(Re-)fetch the data-request identifier from the metadata endpoint.
+
+        Returns the identifier and updates the cache when the portal hands out a
+        *new* one (e.g. after the continuous data subscription was deleted and
+        recreated, which assigns a fresh identifier and silently invalidates the
+        stored one). Returns ``None`` when it is unavailable or unchanged.
+        """
+        try:
+            meta = self.client.get_metadata(vin)
+        except ApiError as err:
+            LOG.debug('Could not refresh data-request identifier for %s: %s', vin, err)
+            return None
+        new_id = meta.get('Identifier') or meta.get('identifier')
+        if not new_id or new_id == self._identifiers.get(vin):
+            return None
+        if vin in self._identifiers:
+            LOG.warning('Data-request identifier for %s changed (%s -> %s); the portal '
+                        'subscription was likely recreated. Using the new identifier.',
+                        vin, self._identifiers[vin], new_id)
+        self._identifiers[vin] = new_id
+        return new_id
+
+    def _list_datasets_with_refresh(self, vin: str, identifier: str) -> "Tuple[List[dict], str]":
+        """List datasets, self-healing a stale identifier once if needed.
+
+        A recreated subscription makes the stored identifier stale: the listing
+        then errors or comes back empty. On either signal, re-fetch the
+        identifier and retry once before giving up, so the connector recovers
+        automatically on the next cycle without a manual reload. The metadata
+        call only happens on that failure/empty signal, so there is no extra API
+        load in normal operation. (HA 2c979c7, issue #13)
+        """
+        listing: "List[dict]" = []
+        for retried in (False, True):
+            try:
+                listing = self.client.list_datasets(vin, identifier)
+            except ApiError:
+                if not retried:
+                    new_id = self._refresh_identifier(vin)
+                    if new_id is not None:
+                        identifier = new_id
+                        continue
+                raise
+            # An empty listing can also mean the subscription was recreated.
+            if not listing and not retried:
+                new_id = self._refresh_identifier(vin)
+                if new_id is not None:
+                    identifier = new_id
+                    continue
+            break
+        return listing, identifier
+
     def _update_vehicle(self, vin: str) -> "Optional[datetime]":
-        """Fetch and map the newest dataset for ``vin``; return its createdOn."""
+        """Fetch and map the newest dataset for ``vin``; return its createdOn.
+
+        On the first call per VIN (bootstrap), downloads ALL available ZIP files
+        chronologically, merges their values field-by-field (latest wins), and maps
+        the merged dataset onto CarConnectivity attributes. Detects field names
+        that are not yet mapped and logs them as new/unmapped sensors.
+
+        Returns the createdOn of the newest *listing entry* (content or "no
+        content"), which marks the delivery cadence and drives the reschedule:
+        the portal emits one zip per ~15-min interval, so the next one is due
+        ~15 min after the newest one regardless of whether it carried data.
+        Returns ``None`` only when there is nothing dated to schedule from
+        (empty/unprovisioned listing), in which case the caller retries soon.
+        """
         identifier = self._identifiers.get(vin)
         if identifier is None:
-            meta = self.client.get_metadata(vin)
-            identifier = meta.get('Identifier')
-            if not identifier:
+            identifier = self._refresh_identifier(vin)
+            if identifier is None:
                 LOG.warning('No data-request identifier for vehicle %s; skipping', vin)
                 return None
-            self._identifiers[vin] = identifier
 
-        listing = self.client.list_datasets(vin, identifier)
-        content = sorted(
-            (e for e in listing if e.get('name') and not e['name'].endswith(NO_CONTENT_SUFFIX)),
-            key=lambda e: _created_on(e) or datetime.min.replace(tzinfo=timezone.utc),
+        listing, identifier = self._list_datasets_with_refresh(vin, identifier)
+        # All named entries, oldest -> newest by createdOn (or filename fallback).
+        dated = sorted(
+            ((e, _created_on(e)) for e in listing if e.get('name')),
+            key=lambda pair: pair[1] or datetime.min.replace(tzinfo=timezone.utc),
         )
-        if not content:
-            LOG.debug('No content datasets available yet for %s', vin)
+
+        if not dated:
             return None
+
+        newest_created = dated[-1][1]
+
+        # Download and map the newest data-bearing dataset. A "no content" zip
+        # for the latest interval means there is simply no data this interval
+        # (not an error or an overdue dataset), so we keep the last known values
+        # and still reschedule ~15 min out from newest_created below. Skip the
+        # download when that dataset is the one we already mapped last time.
+        content = [e for e, _ in dated if not e['name'].endswith(NO_CONTENT_SUFFIX)]
+        if not content:
+            LOG.debug('Latest dataset for %s carries no content; waiting for the next interval', vin)
+            return newest_created
+
+        if vin not in self._bootstrapped:
+            self._bootstrap_vehicle(vin, identifier, content)
+            if vin in self._merged_datasets:
+                self._last_dataset[vin] = content[-1]['name']
+
         newest = content[-1]
-        payload = self.client.download_dataset(vin, identifier, newest['name'])
-        dataset = Dataset.from_json(payload)
-        self._map_dataset(vin, dataset, payload)
-        return _created_on(newest)
+        if self._last_dataset.get(vin) != newest['name']:
+            payload = self.client.download_dataset(vin, identifier, newest['name'])
+            dataset = Dataset.from_json(payload)
+            self._map_dataset(vin, dataset)
+            self._last_dataset[vin] = newest['name']
+        return newest_created
+
+    def _bootstrap_vehicle(self, vin: str, identifier: str, listing: list) -> None:
+        """Download all available ZIP datasets for ``vin``, merge chronologically,
+        map the merged result, and mark the vehicle as bootstrapped."""
+        LOG.info('Bootstrapping vehicle %s: downloading %d datasets', vin, len(listing))
+        datasets: list = []
+        for entry in listing:
+            name = entry['name']
+            try:
+                payload = self.client.download_dataset(vin, identifier, name)
+                datasets.append(Dataset.from_json(payload))
+                LOG.debug('Bootstrap %s: downloaded %s', vin, name)
+            except ApiError as err:
+                LOG.warning('Bootstrap %s: failed to download %s: %s', vin, name, err)
+        if not datasets:
+            LOG.warning('Bootstrap %s: no datasets could be downloaded', vin)
+            self._bootstrapped.add(vin)
+            return
+
+        merged = Dataset.merge(datasets)
+        self._merged_datasets[vin] = merged
+        self._observed_fields[vin] = set(merged.field_names)
+        self._detect_unmapped_fields(vin, merged)
+        self._map_dataset(vin, merged)
+        self._bootstrapped.add(vin)
+        LOG.info('Bootstrapped vehicle %s: merged %d datasets, %d unique fields',
+                 vin, len(datasets), len(merged.field_names))
+
+    @staticmethod
+    def _detect_unmapped_fields(vin: str, dataset: Dataset) -> None:
+        """Log any field names in the dataset that are not yet mapped to CarConnectivity."""
+        unmapped = dataset.field_names - KNOWN_MAPPED_FIELDS
+        for field in sorted(unmapped):
+            dp = dataset.by_field(field)
+            raw = dp.raw_value if dp else '?'
+            LOG.info('New unmapped sensor for %s: field=%s value=%s', vin, field, raw)
 
     # -- mapping -----------------------------------------------------------
 
-    def _extract_flat_fields(self, payload: dict) -> dict:
-        """Return a {fieldName: value} dict if payload is the eGolf flat format, else {}.
-
-        The eGolf portal delivers a flat ``Data`` array of
-        ``{dataFieldName, value, ...}`` objects instead of the nested report
-        structure used by ID.x vehicles. This helper detects that layout and
-        converts it into a plain dict for easy lookup. Entries with a missing
-        or empty value are skipped.
-        """
-        data_list = payload.get('Data') if isinstance(payload, dict) else None
-        if not isinstance(data_list, list):
-            return {}
-        # Only treat it as flat format when field names look like eGolf style
-        # (no dots) rather than ID.x style (e.g. "battery_state_report.soc").
-        result = {}
-        for item in data_list:
-            name = item.get('dataFieldName', '')
-            value = item.get('value')
-            if name and value not in (None, ''):
-                result[name] = value
-        if not result:
-            return {}
-        # If any field name contains a dot it is ID.x nested format, not flat.
-        if any('.' in k for k in result):
-            return {}
-        return result
-
-    def _map_dataset(self, vin: str, dataset: Dataset, payload: Optional[dict] = None) -> None:
+    def _map_dataset(self, vin: str, dataset: Dataset) -> None:
         """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only)."""
         garage: Garage = self.car_connectivity.garage
-        vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)  # pyright: ignore[reportAssignmentType]
+        vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)
         if vehicle is None:
             return
+    
         captured_at = dataset.captured_at
-
-        # --- eGolf / flat key-value format -----------------------------------
-        # The eGolf delivers a flat Data array (no dotted field names) instead
-        # of the nested report structure used by ID.x vehicles. Detect it here
-        # and hand off to the dedicated mapper; skip the ID.x path entirely.
-        flat_fields = self._extract_flat_fields(payload) if payload is not None else {}
-        if flat_fields:
-            LOG.debug('Detected flat (eGolf) dataset format for %s', vin)
-            self._map_flat_dataset(vehicle, garage, vin, flat_fields, captured_at)
-            return
-        # ---------------------------------------------------------------------
-
-        # Promote to an electric vehicle once we see EV-specific data.
-        is_ev = dataset.by_field('battery_state_report.soc') is not None \
-            or dataset.by_field('battery_state_report.charge_power') is not None \
+    
+        # -------------------------
+        # EV PROMOTION DETECTION (FIXED)
+        # -------------------------
+        is_ev = (
+            dataset.by_field('battery_state_report.soc') is not None
+            or dataset.by_field('battery_state_report.charge_power') is not None
             or dataset.by_field('charging_state_report.current_charge_state') is not None
+            or dataset.by_field('state_of_charge') is not None   # <-- eGolf FIX
+            or dataset.by_field('cruising_range_primary_engine') is not None  # <-- eGolf FIX
+        )
+    
         if is_ev and not isinstance(vehicle, VWEudaElectricVehicle):
-            LOG.debug('Promoting %s to VWEudaElectricVehicle for %s', vehicle.__class__.__name__, vin)
+            LOG.debug('Promoting %s to VWEudaElectricVehicle for %s',
+                      vehicle.__class__.__name__, vin)
             vehicle = VWEudaElectricVehicle(garage=garage, origin=vehicle)
             garage.replace_vehicle(vin, vehicle)
-            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)  # pylint: disable=protected-access
-
-        # Odometer (mileage.value). The portal reports km or miles depending on
-        # the vehicle; the unit comes from the companion mileage.unit enum, with
-        # km as the fallback when that field is absent.
+            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)
+    
+        # -------------------------
+        # EXISTING MAPPING (UNCHANGED)
+        # -------------------------
         mileage = dataset.value_of('mileage.value')
         if mileage is not None:
             mileage_unit = Length.MI if resolve_distance_unit(dataset.value_of('mileage.unit')) == 'mi' else Length.KM
-            vehicle.odometer._set_value(value=mileage, measured=captured_at, unit=mileage_unit)  # pylint: disable=protected-access
+            vehicle.odometer._set_value(value=mileage, measured=captured_at, unit=mileage_unit)
             vehicle.odometer.precision = 1
-
-        # Doors lock state
+    
         locked = dataset.value_of('locked')
         if isinstance(locked, bool):
-            vehicle.doors.lock_state._set_value(  # pylint: disable=protected-access
-                Doors.LockState.LOCKED if locked else Doors.LockState.UNLOCKED, measured=captured_at)
-
-        # Window heating state
+            vehicle.doors.lock_state._set_value(
+                Doors.LockState.LOCKED if locked else Doors.LockState.UNLOCKED,
+                measured=captured_at
+            )
+    
         wh = dataset.value_of('window_heating_state')
         if isinstance(wh, str):
-            vehicle.window_heatings.heating_state._set_value(  # pylint: disable=protected-access
-                WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN), measured=captured_at)
-
+            vehicle.window_heatings.heating_state._set_value(
+                WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN),
+                measured=captured_at
+            )
+    
+        # -------------------------
+        # EV STRUCTURED MAPPING (UNCHANGED)
+        # -------------------------
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)
-
-    def _map_flat_dataset(self, vehicle: VWEudaVehicle, garage: Garage, vin: str,
-                          fields: dict, captured_at: "Optional[datetime]") -> None:
-        """Map the eGolf flat key-value Data array onto CarConnectivity attributes."""
-        # Promote to electric vehicle
-        if not isinstance(vehicle, VWEudaElectricVehicle):
-            LOG.debug('Promoting %s to VWEudaElectricVehicle (flat format) for %s', vehicle.__class__.__name__, vin)
-            vehicle = VWEudaElectricVehicle(garage=garage, origin=vehicle)
-            garage.replace_vehicle(vin, vehicle)
-            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)  # pylint: disable=protected-access
-
-        drive = vehicle.get_electric_drive()
-        if drive is None:
-            drive = ElectricDrive(drive_id='primary', drives=vehicle.drives,
-                                  initialization=vehicle.drives.get_initialization('primary'))
-            drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
-            vehicle.drives.add_drive(drive)
-
-        # State of charge (%) — priority field
-        if 'state_of_charge' in fields:
-            try:
-                drive.level._set_value(value=int(fields['state_of_charge']),  # pylint: disable=protected-access
-                                       measured=captured_at)
+    
+            drive = vehicle.get_electric_drive()
+            if drive is None:
+                drive = ElectricDrive(
+                    drive_id='primary',
+                    drives=vehicle.drives,
+                    initialization=vehicle.drives.get_initialization('primary')
+                )
+                drive.type._set_value(GenericDrive.Type.ELECTRIC)
+                vehicle.drives.add_drive(drive)
+    
+            # -------------------------
+            # FLAT FIELD EXTENSION (NEW BUT SAFE)
+            # -------------------------
+    
+            # state_of_charge (eGolf)
+            soc = dataset.value_of('state_of_charge')
+            if soc is not None:
+                drive.level._set_value(value=soc, measured=captured_at)
                 drive.level.precision = 1
-                LOG.debug('eGolf %s: state_of_charge=%s%%', vin, fields['state_of_charge'])
-            except (ValueError, TypeError) as exc:
-                LOG.warning('eGolf %s: could not parse state_of_charge %r: %s', vin, fields['state_of_charge'], exc)
-
-        # Cruising range (km)
-        if 'cruising_range_primary_engine' in fields:
-            try:
-                drive.range._set_value(value=int(fields['cruising_range_primary_engine']),  # pylint: disable=protected-access
-                                       measured=captured_at, unit=Length.KM)
+    
+            # cruising range (eGolf)
+            rng = dataset.value_of('cruising_range_primary_engine')
+            if rng is not None:
+                drive.range._set_value(value=rng, measured=captured_at, unit=Length.KM)
                 drive.range.precision = 1
-            except (ValueError, TypeError) as exc:
-                LOG.warning('eGolf %s: could not parse cruising_range_primary_engine %r: %s',
-                            vin, fields['cruising_range_primary_engine'], exc)
-
-        # Charging state
-        if 'charging_state' in fields:
-            mapped = FLAT_CHARGE_STATE_MAPPING.get(fields['charging_state'], Charging.ChargingState.UNKNOWN)
-            vehicle.charging.state._set_value(mapped, measured=captured_at)  # pylint: disable=protected-access
-
-        # Odometer (km)
-        if 'mileage' in fields:
-            try:
-                vehicle.odometer._set_value(value=int(fields['mileage']),  # pylint: disable=protected-access
-                                            measured=captured_at, unit=Length.KM)
+    
+            # flat mileage fallback (some datasets only provide this)
+            flat_mileage = dataset.value_of('mileage')
+            if flat_mileage is not None and mileage is None:
+                vehicle.odometer._set_value(value=flat_mileage, measured=captured_at, unit=Length.KM)
                 vehicle.odometer.precision = 1
-            except (ValueError, TypeError) as exc:
-                LOG.warning('eGolf %s: could not parse mileage %r: %s', vin, fields['mileage'], exc)
-
-        # Lock state
-        if 'lock_state' in fields:
-            lock_map = {
-                'locked':   Doors.LockState.LOCKED,
-                'unlocked': Doors.LockState.UNLOCKED,
-            }
-            vehicle.doors.lock_state._set_value(  # pylint: disable=protected-access
-                lock_map.get(fields['lock_state'], Doors.LockState.UNKNOWN), measured=captured_at)
-
-        # Outside temperature — portal delivers tenths of Kelvin (e.g. 2956 = 22.45 °C)
-        if 'outside_temperature' in fields:
-            try:
-                kelvin_tenth = int(fields['outside_temperature'])
-                celsius = round((kelvin_tenth / 10.0) - 273.15, 1)
-                vehicle.outside_temperature._set_value(  # pylint: disable=protected-access
-                    value=celsius, measured=captured_at, unit=Temperature.C)
-            except (ValueError, TypeError) as exc:
-                LOG.warning('eGolf %s: could not parse outside_temperature %r: %s',
-                            vin, fields['outside_temperature'], exc)
-
-
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
                       captured_at: "Optional[datetime]") -> None:
@@ -535,6 +646,28 @@ class Connector(BaseConnector):
         if isinstance(charge_state, str):
             vehicle.charging.state._set_value(  # pylint: disable=protected-access
                 CHARGE_STATE_MAPPING.get(charge_state, Charging.ChargingState.UNKNOWN), measured=captured_at)
+
+        # Charge type (what the car is plugged into: AC / DC / off)
+        charge_type = dataset.value_of('charging_state_report.charge_type')
+        if isinstance(charge_type, str):
+            vehicle.charging.type._set_value(  # pylint: disable=protected-access
+                CHARGE_TYPE_MAPPING.get(charge_type, Charging.ChargingType.UNKNOWN), measured=captured_at)
+
+        # Charge rate (range gained over time). The unit comes from the companion
+        # charge_rate_unit enum (km/mi, per-h/min); normalise to a per-hour speed.
+        charge_rate = dataset.value_of('battery_state_report.charge_rate')
+        if charge_rate is not None:
+            rate_value, rate_unit = _charge_rate_per_hour(
+                charge_rate, dataset.value_of('battery_state_report.charge_rate_unit'))
+            vehicle.charging.rate._set_value(value=rate_value, measured=captured_at, unit=rate_unit)  # pylint: disable=protected-access
+
+        # Remaining time to a full charge -> estimated completion timestamp
+        # (the native attribute is a date, so add the remaining seconds to the
+        # capture time rather than exposing a raw duration).
+        remaining = dataset.value_of('battery_state_report.remaining_charging_time_complete')
+        if remaining is not None and captured_at is not None:
+            vehicle.charging.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                value=captured_at + timedelta(seconds=remaining), measured=captured_at)
 
         # Target state of charge (%) - read-only here (no commands possible).
         target_soc = dataset.value_of('settings.target_soc')

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -80,12 +80,18 @@ CHARGE_STATE_MAPPING: "Dict[str, Charging.ChargingState]" = {
     'CHARGE_STATE_CHARGING_ERROR': Charging.ChargingState.ERROR,
 }
 
+# Map eGolf flat charging_state strings to CarConnectivity enums.
+FLAT_CHARGE_STATE_MAPPING: "Dict[str, Charging.ChargingState]" = {
+    'charging':     Charging.ChargingState.CHARGING,
+    'not_charging': Charging.ChargingState.OFF,
+    'complete':     Charging.ChargingState.CONSERVATION,
+}
+
 WINDOW_HEATING_MAPPING: "Dict[str, WindowHeatings.HeatingState]" = {
     'WINDOW_HEATING_STATE_OFF': WindowHeatings.HeatingState.OFF,
     'WINDOW_HEATING_STATE_ON': WindowHeatings.HeatingState.ON,
     'WINDOW_HEATING_STATE_INVALID': WindowHeatings.HeatingState.INVALID,
 }
-
 
 def _filename_timestamp(name: str) -> "Optional[datetime]":
     """Parse a YYYYMMDDhhmmss segment from a dataset filename.
@@ -330,18 +336,56 @@ class Connector(BaseConnector):
         newest = content[-1]
         payload = self.client.download_dataset(vin, identifier, newest['name'])
         dataset = Dataset.from_json(payload)
-        self._map_dataset(vin, dataset)
+        self._map_dataset(vin, dataset, payload)
         return _created_on(newest)
 
     # -- mapping -----------------------------------------------------------
 
-    def _map_dataset(self, vin: str, dataset: Dataset) -> None:
+    def _extract_flat_fields(self, payload: dict) -> dict:
+        """Return a {fieldName: value} dict if payload is the eGolf flat format, else {}.
+
+        The eGolf portal delivers a flat ``Data`` array of
+        ``{dataFieldName, value, ...}`` objects instead of the nested report
+        structure used by ID.x vehicles. This helper detects that layout and
+        converts it into a plain dict for easy lookup. Entries with a missing
+        or empty value are skipped.
+        """
+        data_list = payload.get('Data') if isinstance(payload, dict) else None
+        if not isinstance(data_list, list):
+            return {}
+        # Only treat it as flat format when field names look like eGolf style
+        # (no dots) rather than ID.x style (e.g. "battery_state_report.soc").
+        result = {}
+        for item in data_list:
+            name = item.get('dataFieldName', '')
+            value = item.get('value')
+            if name and value not in (None, ''):
+                result[name] = value
+        if not result:
+            return {}
+        # If any field name contains a dot it is ID.x nested format, not flat.
+        if any('.' in k for k in result):
+            return {}
+        return result
+
+    def _map_dataset(self, vin: str, dataset: Dataset, payload: dict) -> None:
         """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only)."""
         garage: Garage = self.car_connectivity.garage
         vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)  # pyright: ignore[reportAssignmentType]
         if vehicle is None:
             return
         captured_at = dataset.captured_at
+
+        # --- eGolf / flat key-value format -----------------------------------
+        # The eGolf delivers a flat Data array (no dotted field names) instead
+        # of the nested report structure used by ID.x vehicles. Detect it here
+        # and hand off to the dedicated mapper; skip the ID.x path entirely.
+        flat_fields = self._extract_flat_fields(payload)
+        if flat_fields:
+            LOG.debug('Detected flat (eGolf) dataset format for %s', vin)
+            self._map_flat_dataset(vehicle, garage, vin, flat_fields, captured_at)
+            return
+        # ---------------------------------------------------------------------
 
         # Promote to an electric vehicle once we see EV-specific data.
         is_ev = dataset.by_field('battery_state_report.soc') is not None \
@@ -376,6 +420,79 @@ class Connector(BaseConnector):
 
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)
+
+    def _map_flat_dataset(self, vehicle: VWEudaVehicle, garage: Garage, vin: str,
+                          fields: dict, captured_at: "Optional[datetime]") -> None:
+        """Map the eGolf flat key-value Data array onto CarConnectivity attributes."""
+        # Promote to electric vehicle
+        if not isinstance(vehicle, VWEudaElectricVehicle):
+            LOG.debug('Promoting %s to VWEudaElectricVehicle (flat format) for %s', vehicle.__class__.__name__, vin)
+            vehicle = VWEudaElectricVehicle(garage=garage, origin=vehicle)
+            garage.replace_vehicle(vin, vehicle)
+            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)  # pylint: disable=protected-access
+
+        drive = vehicle.get_electric_drive()
+        if drive is None:
+            drive = ElectricDrive(drive_id='primary', drives=vehicle.drives,
+                                  initialization=vehicle.drives.get_initialization('primary'))
+            drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
+            vehicle.drives.add_drive(drive)
+
+        # State of charge (%) — priority field
+        if 'state_of_charge' in fields:
+            try:
+                drive.level._set_value(value=int(fields['state_of_charge']),  # pylint: disable=protected-access
+                                       measured=captured_at)
+                drive.level.precision = 1
+                LOG.debug('eGolf %s: state_of_charge=%s%%', vin, fields['state_of_charge'])
+            except (ValueError, TypeError) as exc:
+                LOG.warning('eGolf %s: could not parse state_of_charge %r: %s', vin, fields['state_of_charge'], exc)
+
+        # Cruising range (km)
+        if 'cruising_range_primary_engine' in fields:
+            try:
+                drive.range._set_value(value=int(fields['cruising_range_primary_engine']),  # pylint: disable=protected-access
+                                       measured=captured_at, unit=Length.KM)
+                drive.range.precision = 1
+            except (ValueError, TypeError) as exc:
+                LOG.warning('eGolf %s: could not parse cruising_range_primary_engine %r: %s',
+                            vin, fields['cruising_range_primary_engine'], exc)
+
+        # Charging state
+        if 'charging_state' in fields:
+            mapped = FLAT_CHARGE_STATE_MAPPING.get(fields['charging_state'], Charging.ChargingState.UNKNOWN)
+            vehicle.charging.state._set_value(mapped, measured=captured_at)  # pylint: disable=protected-access
+
+        # Odometer (km)
+        if 'mileage' in fields:
+            try:
+                vehicle.odometer._set_value(value=int(fields['mileage']),  # pylint: disable=protected-access
+                                            measured=captured_at, unit=Length.KM)
+                vehicle.odometer.precision = 1
+            except (ValueError, TypeError) as exc:
+                LOG.warning('eGolf %s: could not parse mileage %r: %s', vin, fields['mileage'], exc)
+
+        # Lock state
+        if 'lock_state' in fields:
+            lock_map = {
+                'locked':   Doors.LockState.LOCKED,
+                'unlocked': Doors.LockState.UNLOCKED,
+            }
+            vehicle.doors.lock_state._set_value(  # pylint: disable=protected-access
+                lock_map.get(fields['lock_state'], Doors.LockState.UNKNOWN), measured=captured_at)
+
+        # Outside temperature — portal delivers tenths of Kelvin (e.g. 2956 = 22.45 °C)
+        if 'outside_temperature' in fields:
+            try:
+                kelvin_tenth = int(fields['outside_temperature'])
+                celsius = round((kelvin_tenth / 10.0) - 273.15, 1)
+                vehicle.outside_temperature._set_value(  # pylint: disable=protected-access
+                    value=celsius, measured=captured_at, unit=Temperature.C)
+            except (ValueError, TypeError) as exc:
+                LOG.warning('eGolf %s: could not parse outside_temperature %r: %s',
+                            vin, fields['outside_temperature'], exc)
+
+
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
                       captured_at: "Optional[datetime]") -> None:

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -5,7 +5,9 @@ CarConnectivity garage and exercises the connector's ``_map_dataset`` against
 the sample dataset shipped by the EU Data Act portal.
 """
 import json
+import logging
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -17,10 +19,10 @@ from carconnectivity.window_heating import WindowHeatings
 
 import requests
 
-from carconnectivity.units import Length
+from carconnectivity.units import Length, Speed
 
 from carconnectivity_connectors.vw_eu_data_act.client import ApiError, EudaApiClient
-from carconnectivity_connectors.vw_eu_data_act.connector import Connector, _filename_timestamp
+from carconnectivity_connectors.vw_eu_data_act.connector import Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS
 from carconnectivity_connectors.vw_eu_data_act.dataset import Dataset
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
 
@@ -287,144 +289,788 @@ def test_network_errors_become_apierror():
         client.download_dataset("WVWZZZE1ZLP010257", "ident", "x.zip")
 
 
-# ---------------------------------------------------------------------------
-# eGolf / flat-format tests
-# ---------------------------------------------------------------------------
-
-def test_extract_flat_fields_detects_egolf_format(connector):
-    """A payload with a Data array and no dotted field names is identified as
-    flat (eGolf) format and returns a populated dict."""
-    fields = connector._extract_flat_fields(EGOLF_PAYLOAD)  # pylint: disable=protected-access
-    assert fields == {
-        "state_of_charge": "26",
-        "cruising_range_primary_engine": "67",
-        "charging_state": "charging",
-        "mileage": "100571",
-        "lock_state": "locked",
-        "outside_temperature": "2956",
-    }
-
-
-def test_extract_flat_fields_rejects_idx_format(connector):
-    """A payload with dotted field names (ID.x nested format) must return {}
-    so the flat path is never triggered for ID.x vehicles."""
-    idxpayload = {"vin": VIN, "Data": [
-        {"key": "k1", "dataFieldName": "battery_state_report.soc", "value": "69"},
-        {"key": "k2", "dataFieldName": "charging_state_report.current_charge_state",
-         "value": "CHARGE_STATE_NOT_READY_FOR_CHARGING"},
-    ]}
-    assert connector._extract_flat_fields(idxpayload) == {}  # pylint: disable=protected-access
-
-
-def test_extract_flat_fields_rejects_none(connector):
-    """None and non-dict inputs must return {} without raising."""
-    assert connector._extract_flat_fields(None) == {}   # pylint: disable=protected-access
-    assert connector._extract_flat_fields({}) == {}     # pylint: disable=protected-access
-
-
-def test_egolf_ev_promotion(connector):
-    """A plain VWEudaVehicle must be promoted to VWEudaElectricVehicle when
-    the flat mapper runs, just as the ID.x path promotes on seeing EV fields."""
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
     garage = connector.car_connectivity.garage
-    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
-    garage.add_vehicle(EGOLF_VIN, vehicle)
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
 
-    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
-                           payload=EGOLF_PAYLOAD)
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
 
-    assert isinstance(garage.get_vehicle(EGOLF_VIN), VWEudaElectricVehicle)
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
 
 
-def test_egolf_state_of_charge(connector):
-    """state_of_charge maps onto drive.level (%)."""
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
     garage = connector.car_connectivity.garage
-    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
-    garage.add_vehicle(EGOLF_VIN, vehicle)
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
 
-    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
-                           payload=EGOLF_PAYLOAD)
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
 
-    drive = garage.get_vehicle(EGOLF_VIN).get_electric_drive()
-    assert drive is not None
-    assert drive.level.value == 26
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
 
 
-def test_egolf_cruising_range(connector):
-    """cruising_range_primary_engine maps onto drive.range (km)."""
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
     garage = connector.car_connectivity.garage
-    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
-    garage.add_vehicle(EGOLF_VIN, vehicle)
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
 
-    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
-                           payload=EGOLF_PAYLOAD)
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
 
-    drive = garage.get_vehicle(EGOLF_VIN).get_electric_drive()
-    assert drive.range.value == 67
-
-
-def test_egolf_charging_state_mapping(connector):
-    """charging_state values map correctly via FLAT_CHARGE_STATE_MAPPING."""
-    garage = connector.car_connectivity.garage
-
-    for flat_value, expected in [
-        ("charging",     Charging.ChargingState.CHARGING),
-        ("not_charging", Charging.ChargingState.OFF),
-        ("complete",     Charging.ChargingState.CONSERVATION),
-        ("unknown_val",  Charging.ChargingState.UNKNOWN),
-    ]:
-        vin = EGOLF_VIN + flat_value  # unique VIN per iteration
-        vehicle = VWEudaVehicle(vin=vin, garage=garage, managing_connector=connector)
-        garage.add_vehicle(vin, vehicle)
-        payload = {"vin": vin, "Data": [
-            {"key": "k1", "dataFieldName": "state_of_charge", "value": "50"},
-            {"key": "k2", "dataFieldName": "charging_state", "value": flat_value},
-        ]}
-        connector._map_dataset(vin, Dataset.from_json(payload),  # pylint: disable=protected-access
-                               payload=payload)
-        assert garage.get_vehicle(vin).charging.state.value == expected, \
-            f"charging_state '{flat_value}' should map to {expected}"
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
 
 
-def test_egolf_mileage(connector):
-    """mileage maps onto vehicle.odometer in km."""
-    garage = connector.car_connectivity.garage
-    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
-    garage.add_vehicle(EGOLF_VIN, vehicle)
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
 
-    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
-                           payload=EGOLF_PAYLOAD)
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
 
-    v = garage.get_vehicle(EGOLF_VIN)
-    assert v.odometer.value == 100571
-    assert v.odometer.unit == Length.KM
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
 
 
-def test_egolf_lock_state(connector):
-    """lock_state 'locked' maps to Doors.LockState.LOCKED."""
-    garage = connector.car_connectivity.garage
-    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
-    garage.add_vehicle(EGOLF_VIN, vehicle)
-
-    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
-                           payload=EGOLF_PAYLOAD)
-
-    assert garage.get_vehicle(EGOLF_VIN).doors.lock_state.value == Doors.LockState.LOCKED
-
-
-def test_egolf_idxpayload_not_hijacked(connector):
-    """An ID.x payload must never be routed through the flat mapper — the
-    detection heuristic (dotted field names -> ID.x) must hold firm."""
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
     garage = connector.car_connectivity.garage
     vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
     garage.add_vehicle(VIN, vehicle)
 
-    idxpayload = json.load(open(SAMPLE, "r", encoding="utf-8"))
-    connector._map_dataset(VIN, Dataset.from_json(idxpayload),  # pylint: disable=protected-access
-                           payload=idxpayload)
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap downloads everything, skips redundant normal fetch
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 1
+
+    # Second call: newest dataset already in _last_dataset, no download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 1
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap downloads everything, skips redundant normal fetch
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 1
+
+    # Second call: newest dataset already in _last_dataset, no download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 1
+    
+def test_flat_data_basic_field_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "12345"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.value == 12345
+    
+def test_flat_data_multiple_fields_mapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "locked", "value": "true"},
+            {"key": "k3", "dataFieldName": "settings.target_soc", "value": "80"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
 
     v = garage.get_vehicle(VIN)
-    # Must have been mapped via the ID.x path, not the flat path
-    assert isinstance(v, VWEudaElectricVehicle)
-    assert v.odometer.value == 116803
-    drive = v.get_electric_drive()
-    assert drive.level.value == 69  # from battery_state_report.soc, not state_of_charge
+    assert v.odometer.value == 100
+    assert v.doors.lock_state.value == Doors.LockState.LOCKED
+    assert v.charging.settings.target_level.value == 80
+    
+def test_flat_data_multiple_fields_mapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "locked", "value": "true"},
+            {"key": "k3", "dataFieldName": "settings.target_soc", "value": "80"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    v = garage.get_vehicle(VIN)
+    assert v.odometer.value == 100
+    assert v.doors.lock_state.value == Doors.LockState.LOCKED
+
+    assert v.charging.settings.target_level.value == 80
+
+def test_flat_data_enum_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state",
+             "value": "CHARGE_STATE_CHARGING"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).charging.state.value == Charging.ChargingState.CHARGING
+    
+def test_flat_data_enum_index_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state",
+             "value": "2"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).charging.state.value == Charging.ChargingState.CHARGING
+    
+def test_flat_data_unit_resolution(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "mileage.unit", "value": "MILES"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.unit == Length.MI
+    
+def test_flat_data_unknown_field_ignored(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "this_field_does_not_exist", "value": "42"},
+            {"key": "k2", "dataFieldName": "mileage.value", "value": "100"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.value == 100

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -27,6 +27,27 @@ from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehi
 SAMPLE = os.path.join(os.path.dirname(__file__), "sample_dataset.json")
 VIN = "WVWZZZE1ZLP010257"
 
+# A minimal eGolf flat-format payload (no dotted field names).
+EGOLF_VIN = "WVWZZZE1ZLP000001"
+EGOLF_PAYLOAD = {
+    "vin": EGOLF_VIN,
+    "user_id": "173ba297-16cd-4da6-bdd7-de433cd4fdf2",
+    "Data": [
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "26", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "55e0d40b-38ed-3cb5-9dcd-6193df6fc493", "dataFieldName": "cruising_range_primary_engine",
+         "value": "67", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "9da735bb-c5d5-39f8-bf53-0fa2a367aa8f", "dataFieldName": "charging_state",
+         "value": "charging", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "41c0805c-43e5-313e-9dfb-356cb8d20f7c", "dataFieldName": "mileage",
+         "value": "100571", "timestampUtc": "2026-05-31T14:11:15.000Z"},
+        {"key": "60bc0937-f5a7-3809-9535-9a7942e5dd94", "dataFieldName": "lock_state",
+         "value": "locked", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "6810b781-e54a-35e8-af98-fcdefb54bac6", "dataFieldName": "outside_temperature",
+         "value": "2956", "timestampUtc": "2026-05-31T14:11:15.000Z"},
+    ]
+}
+
 
 def _load() -> Dataset:
     with open(SAMPLE, "r", encoding="utf-8") as fh:
@@ -264,3 +285,146 @@ def test_network_errors_become_apierror():
         client.list_datasets("WVWZZZE1ZLP010257", "ident")
     with pytest.raises(ApiError):
         client.download_dataset("WVWZZZE1ZLP010257", "ident", "x.zip")
+
+
+# ---------------------------------------------------------------------------
+# eGolf / flat-format tests
+# ---------------------------------------------------------------------------
+
+def test_extract_flat_fields_detects_egolf_format(connector):
+    """A payload with a Data array and no dotted field names is identified as
+    flat (eGolf) format and returns a populated dict."""
+    fields = connector._extract_flat_fields(EGOLF_PAYLOAD)  # pylint: disable=protected-access
+    assert fields == {
+        "state_of_charge": "26",
+        "cruising_range_primary_engine": "67",
+        "charging_state": "charging",
+        "mileage": "100571",
+        "lock_state": "locked",
+        "outside_temperature": "2956",
+    }
+
+
+def test_extract_flat_fields_rejects_idx_format(connector):
+    """A payload with dotted field names (ID.x nested format) must return {}
+    so the flat path is never triggered for ID.x vehicles."""
+    idxpayload = {"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "battery_state_report.soc", "value": "69"},
+        {"key": "k2", "dataFieldName": "charging_state_report.current_charge_state",
+         "value": "CHARGE_STATE_NOT_READY_FOR_CHARGING"},
+    ]}
+    assert connector._extract_flat_fields(idxpayload) == {}  # pylint: disable=protected-access
+
+
+def test_extract_flat_fields_rejects_none(connector):
+    """None and non-dict inputs must return {} without raising."""
+    assert connector._extract_flat_fields(None) == {}   # pylint: disable=protected-access
+    assert connector._extract_flat_fields({}) == {}     # pylint: disable=protected-access
+
+
+def test_egolf_ev_promotion(connector):
+    """A plain VWEudaVehicle must be promoted to VWEudaElectricVehicle when
+    the flat mapper runs, just as the ID.x path promotes on seeing EV fields."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(EGOLF_VIN, vehicle)
+
+    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
+                           payload=EGOLF_PAYLOAD)
+
+    assert isinstance(garage.get_vehicle(EGOLF_VIN), VWEudaElectricVehicle)
+
+
+def test_egolf_state_of_charge(connector):
+    """state_of_charge maps onto drive.level (%)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(EGOLF_VIN, vehicle)
+
+    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
+                           payload=EGOLF_PAYLOAD)
+
+    drive = garage.get_vehicle(EGOLF_VIN).get_electric_drive()
+    assert drive is not None
+    assert drive.level.value == 26
+
+
+def test_egolf_cruising_range(connector):
+    """cruising_range_primary_engine maps onto drive.range (km)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(EGOLF_VIN, vehicle)
+
+    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
+                           payload=EGOLF_PAYLOAD)
+
+    drive = garage.get_vehicle(EGOLF_VIN).get_electric_drive()
+    assert drive.range.value == 67
+
+
+def test_egolf_charging_state_mapping(connector):
+    """charging_state values map correctly via FLAT_CHARGE_STATE_MAPPING."""
+    garage = connector.car_connectivity.garage
+
+    for flat_value, expected in [
+        ("charging",     Charging.ChargingState.CHARGING),
+        ("not_charging", Charging.ChargingState.OFF),
+        ("complete",     Charging.ChargingState.CONSERVATION),
+        ("unknown_val",  Charging.ChargingState.UNKNOWN),
+    ]:
+        vin = EGOLF_VIN + flat_value  # unique VIN per iteration
+        vehicle = VWEudaVehicle(vin=vin, garage=garage, managing_connector=connector)
+        garage.add_vehicle(vin, vehicle)
+        payload = {"vin": vin, "Data": [
+            {"key": "k1", "dataFieldName": "state_of_charge", "value": "50"},
+            {"key": "k2", "dataFieldName": "charging_state", "value": flat_value},
+        ]}
+        connector._map_dataset(vin, Dataset.from_json(payload),  # pylint: disable=protected-access
+                               payload=payload)
+        assert garage.get_vehicle(vin).charging.state.value == expected, \
+            f"charging_state '{flat_value}' should map to {expected}"
+
+
+def test_egolf_mileage(connector):
+    """mileage maps onto vehicle.odometer in km."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(EGOLF_VIN, vehicle)
+
+    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
+                           payload=EGOLF_PAYLOAD)
+
+    v = garage.get_vehicle(EGOLF_VIN)
+    assert v.odometer.value == 100571
+    assert v.odometer.unit == Length.KM
+
+
+def test_egolf_lock_state(connector):
+    """lock_state 'locked' maps to Doors.LockState.LOCKED."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=EGOLF_VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(EGOLF_VIN, vehicle)
+
+    connector._map_dataset(EGOLF_VIN, Dataset.from_json(EGOLF_PAYLOAD),  # pylint: disable=protected-access
+                           payload=EGOLF_PAYLOAD)
+
+    assert garage.get_vehicle(EGOLF_VIN).doors.lock_state.value == Doors.LockState.LOCKED
+
+
+def test_egolf_idxpayload_not_hijacked(connector):
+    """An ID.x payload must never be routed through the flat mapper — the
+    detection heuristic (dotted field names -> ID.x) must hold firm."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    idxpayload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+    connector._map_dataset(VIN, Dataset.from_json(idxpayload),  # pylint: disable=protected-access
+                           payload=idxpayload)
+
+    v = garage.get_vehicle(VIN)
+    # Must have been mapped via the ID.x path, not the flat path
+    assert isinstance(v, VWEudaElectricVehicle)
+    assert v.odometer.value == 116803
+    drive = v.get_electric_drive()
+    assert drive.level.value == 69  # from battery_state_report.soc, not state_of_charge


### PR DESCRIPTION
## Add support for eGolf (and other pre-ID.x) flat dataset format

### Problem

The connector was built around the nested report structure delivered by ID.x vehicles (field names like `battery_state_report.soc`, `charging_state_report.current_charge_state`). Older electric vehicles such as the **eGolf** receive a flat `Data` array instead, where each entry has a simple `dataFieldName` (e.g. `state_of_charge`, `charging_state`, `mileage`) with no dotted hierarchy. As a result, the connector mapped no data at all for these vehicles.

### Solution

Added automatic format detection in `_extract_flat_fields()`: if the `Data` array is present and none of the field names contain a dot, the payload is treated as the flat eGolf format and handed off to a new dedicated mapper `_map_flat_dataset()`. ID.x vehicles are unaffected — their dotted field names cause `_extract_flat_fields()` to return `{}` and the original code path runs unchanged.

### Mapped fields (eGolf / flat format)

| Portal field | CarConnectivity attribute |
|---|---|
| `state_of_charge` | `drive.level` (%) |
| `cruising_range_primary_engine` | `drive.range` (km) |
| `charging_state` | `vehicle.charging.state` |
| `mileage` | `vehicle.odometer` (km) |
| `lock_state` | `vehicle.doors.lock_state` |
| `outside_temperature` | `vehicle.outside_temperature` (°C, converted from tenths of Kelvin) |

### Tested on

Volkswagen eGolf — confirmed working against the EU Data Act portal.

### Note

I developed and tested this fix with the assistance of Claude (Anthropic's AI assistant), which helped analyse the data format, identify the structural difference from ID.x vehicles, and work through several iterations to get the attribute mapping right.