### PR TITLE
Bootstrap functionality

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -465,6 +465,8 @@ class Connector(BaseConnector):
 
         if vin not in self._bootstrapped:
             self._bootstrap_vehicle(vin, identifier, content)
+            if vin in self._merged_datasets:
+                self._last_dataset[vin] = content[-1]['name']
 
         newest = content[-1]
         if self._last_dataset.get(vin) != newest['name']:

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -451,7 +451,10 @@ class Connector(BaseConnector):
             key=lambda pair: pair[1] or datetime.min.replace(tzinfo=timezone.utc),
         )
 
-                newest_created = dated[-1][1]
+        if not dated:
+            return None
+
+        newest_created = dated[-1][1]
 
         # Download and map the newest data-bearing dataset. A "no content" zip
         # for the latest interval means there is simply no data this interval

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -140,6 +140,24 @@ def _created_on(entry: dict) -> "Optional[datetime]":
     return parsed if parsed is not None else _filename_timestamp(entry.get("name", ""))
 
 
+# --- Known mapped fields for detecting unmapped sensors --------------------
+KNOWN_MAPPED_FIELDS: set[str] = {
+    'mileage.value',
+    'mileage.unit',
+    'mileage.state',
+    'locked',
+    'window_heating_state',
+    'battery_state_report.soc',
+    'range',
+    'min_temperature',
+    'max_temperature',
+    'battery_state_report.charge_power',
+    'charging_state_report.current_charge_state',
+    'settings.target_soc',
+    'car_captured_time',
+}
+
+
 class Connector(BaseConnector):
     """Read-only connector for the Volkswagen EU Data Act portal."""
 
@@ -161,6 +179,12 @@ class Connector(BaseConnector):
         # mapped, so intervals that produced only a "no content" zip don't trigger
         # a redundant re-download of the same dataset.
         self._last_dataset: Dict[str, str] = {}
+        # Tracks whether the initial bootstrap (download all zips, build cache) has run per VIN.
+        self._bootstrapped: set[str] = set()
+        # Merged dataset per VIN tracking the latest value per field across all downloaded zips.
+        self._merged_datasets: Dict[str, Dataset] = {}
+        # Set of field names already observed per VIN (used to detect new/unmapped sensors).
+        self._observed_fields: Dict[str, set] = {}
 
         self.connection_state: EnumAttribute[ConnectionState] = EnumAttribute(
             name="connection_state", parent=self, value_type=ConnectionState,
@@ -399,7 +423,12 @@ class Connector(BaseConnector):
         return listing, identifier
 
     def _update_vehicle(self, vin: str) -> "Optional[datetime]":
-        """Fetch and map the newest dataset for ``vin``.
+        """Fetch and map the newest dataset for ``vin``; return its createdOn.
+
+        On the first call per VIN (bootstrap), downloads ALL available ZIP files
+        chronologically, merges their values field-by-field (latest wins), and maps
+        the merged dataset onto CarConnectivity attributes. Detects field names
+        that are not yet mapped and logs them as new/unmapped sensors.
 
         Returns the createdOn of the newest *listing entry* (content or "no
         content"), which marks the delivery cadence and drives the reschedule:
@@ -421,10 +450,8 @@ class Connector(BaseConnector):
             ((e, _created_on(e)) for e in listing if e.get('name')),
             key=lambda pair: pair[1] or datetime.min.replace(tzinfo=timezone.utc),
         )
-        if not dated:
-            LOG.debug('No datasets available yet for %s', vin)
-            return None
-        newest_created = dated[-1][1]
+
+                newest_created = dated[-1][1]
 
         # Download and map the newest data-bearing dataset. A "no content" zip
         # for the latest interval means there is simply no data this interval
@@ -432,15 +459,56 @@ class Connector(BaseConnector):
         # and still reschedule ~15 min out from newest_created below. Skip the
         # download when that dataset is the one we already mapped last time.
         content = [e for e, _ in dated if not e['name'].endswith(NO_CONTENT_SUFFIX)]
-        if content:
-            newest = content[-1]
-            if self._last_dataset.get(vin) != newest['name']:
-                payload = self.client.download_dataset(vin, identifier, newest['name'])
-                self._map_dataset(vin, Dataset.from_json(payload))
-                self._last_dataset[vin] = newest['name']
-        else:
+        if not content:
             LOG.debug('Latest dataset for %s carries no content; waiting for the next interval', vin)
+            return newest_created
+
+        if vin not in self._bootstrapped:
+            self._bootstrap_vehicle(vin, identifier, content)
+
+        newest = content[-1]
+        if self._last_dataset.get(vin) != newest['name']:
+            payload = self.client.download_dataset(vin, identifier, newest['name'])
+            dataset = Dataset.from_json(payload)
+            self._map_dataset(vin, dataset)
+            self._last_dataset[vin] = newest['name']
         return newest_created
+
+    def _bootstrap_vehicle(self, vin: str, identifier: str, listing: list) -> None:
+        """Download all available ZIP datasets for ``vin``, merge chronologically,
+        map the merged result, and mark the vehicle as bootstrapped."""
+        LOG.info('Bootstrapping vehicle %s: downloading %d datasets', vin, len(listing))
+        datasets: list = []
+        for entry in listing:
+            name = entry['name']
+            try:
+                payload = self.client.download_dataset(vin, identifier, name)
+                datasets.append(Dataset.from_json(payload))
+                LOG.debug('Bootstrap %s: downloaded %s', vin, name)
+            except ApiError as err:
+                LOG.warning('Bootstrap %s: failed to download %s: %s', vin, name, err)
+        if not datasets:
+            LOG.warning('Bootstrap %s: no datasets could be downloaded', vin)
+            self._bootstrapped.add(vin)
+            return
+
+        merged = Dataset.merge(datasets)
+        self._merged_datasets[vin] = merged
+        self._observed_fields[vin] = set(merged.field_names)
+        self._detect_unmapped_fields(vin, merged)
+        self._map_dataset(vin, merged)
+        self._bootstrapped.add(vin)
+        LOG.info('Bootstrapped vehicle %s: merged %d datasets, %d unique fields',
+                 vin, len(datasets), len(merged.field_names))
+
+    @staticmethod
+    def _detect_unmapped_fields(vin: str, dataset: Dataset) -> None:
+        """Log any field names in the dataset that are not yet mapped to CarConnectivity."""
+        unmapped = dataset.field_names - KNOWN_MAPPED_FIELDS
+        for field in sorted(unmapped):
+            dp = dataset.by_field(field)
+            raw = dp.raw_value if dp else '?'
+            LOG.info('New unmapped sensor for %s: field=%s value=%s', vin, field, raw)
 
     # -- mapping -----------------------------------------------------------
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -246,6 +246,26 @@ class Dataset:
             captured_at=max(captured) if captured else None,
         )
 
+    @classmethod
+    def merge(cls, datasets: list) -> "Dataset":
+        if not datasets:
+            raise ValueError("Cannot merge empty list of datasets")
+        merged_vin = datasets[-1].vin
+        merged_user = datasets[-1].user_id
+        merged_captured = None
+        latest: dict = {}
+        for ds in datasets:
+            for field_name in ds.field_names:
+                dp = ds.by_field(field_name)
+                if dp is not None:
+                    latest[field_name] = dp
+            if ds.captured_at and (merged_captured is None or ds.captured_at > merged_captured):
+                merged_captured = ds.captured_at
+        merged_pkeys = {}
+        for dp in latest.values():
+            merged_pkeys[dp.key] = dp
+        return cls(vin=merged_vin, user_id=merged_user, points=merged_pkeys, captured_at=merged_captured)
+
     def by_field(self, field_name: str) -> Optional[DataPoint]:
         """Return a single data point for a (possibly duplicated) field name.
 
@@ -264,3 +284,7 @@ class Dataset:
         """Return the typed value of ``field_name`` or ``None`` if absent."""
         dp = self.by_field(field_name)
         return dp.value if dp is not None else None
+
+    @property
+    def field_names(self) -> set:
+        return {dp.field_name for dp in self.points.values()}

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -21,7 +21,7 @@ import requests
 from carconnectivity.units import Length, Speed
 
 from carconnectivity_connectors.vw_eu_data_act.client import ApiError, EudaApiClient
-from carconnectivity_connectors.vw_eu_data_act.connector import Connector, _filename_timestamp
+from carconnectivity_connectors.vw_eu_data_act.connector import Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS
 from carconnectivity_connectors.vw_eu_data_act.dataset import Dataset
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
 
@@ -427,3 +427,496 @@ def test_no_datasets_at_all_retries_soon(connector):
     connector.update_vehicles()
 
     assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap + normal fetch = 2 downloads
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 2
+
+    # Second call: only normal fetch = 1 download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 3
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap + normal fetch = 2 downloads
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 2
+
+    # Second call: only normal fetch = 1 download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 3

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -5,6 +5,7 @@ CarConnectivity garage and exercises the connector's ``_map_dataset`` against
 the sample dataset shipped by the EU Data Act portal.
 """
 import json
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 
@@ -389,6 +390,7 @@ def test_no_content_latest_interval_reschedules_to_next_interval(connector):
     # Pretend the older content dataset was already mapped on a previous cycle.
     connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
     connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
 
     class _FakeClient:
         def list_datasets(self, vin, identifier):
@@ -551,6 +553,7 @@ def test_no_content_latest_interval_reschedules_to_next_interval(connector):
     # Pretend the older content dataset was already mapped on a previous cycle.
     connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
     connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
 
     class _FakeClient:
         def list_datasets(self, vin, identifier):
@@ -637,7 +640,8 @@ def test_unmapped_field_detection(caplog):
     ds = Dataset.from_json({"vin": VIN, "Data": [
         {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
     ]})
-    Connector._detect_unmapped_fields(VIN, ds)
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
     assert "New unmapped sensor for" in caplog.text
     assert "some_new_sensor" in caplog.text
 
@@ -667,14 +671,14 @@ def test_bootstrap_skips_already_bootstrapped(connector):
     fake = _FakeClient()
     connector.client = fake
 
-    # First call: bootstrap + normal fetch = 2 downloads
+    # First call: bootstrap downloads everything, skips redundant normal fetch
     connector._update_vehicle(VIN)
     assert VIN in connector._bootstrapped
-    assert fake.download_count == 2
+    assert fake.download_count == 1
 
-    # Second call: only normal fetch = 1 download
+    # Second call: newest dataset already in _last_dataset, no download
     connector._update_vehicle(VIN)
-    assert fake.download_count == 3
+    assert fake.download_count == 1
 
 
 def test_charge_type_rate_and_remaining_time_mapped(connector):
@@ -799,6 +803,7 @@ def test_no_content_latest_interval_reschedules_to_next_interval(connector):
     # Pretend the older content dataset was already mapped on a previous cycle.
     connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
     connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
 
     class _FakeClient:
         def list_datasets(self, vin, identifier):
@@ -885,7 +890,8 @@ def test_unmapped_field_detection(caplog):
     ds = Dataset.from_json({"vin": VIN, "Data": [
         {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
     ]})
-    Connector._detect_unmapped_fields(VIN, ds)
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
     assert "New unmapped sensor for" in caplog.text
     assert "some_new_sensor" in caplog.text
 
@@ -912,11 +918,11 @@ def test_bootstrap_skips_already_bootstrapped(connector):
     fake = _FakeClient()
     connector.client = fake
 
-    # First call: bootstrap + normal fetch = 2 downloads
+    # First call: bootstrap downloads everything, skips redundant normal fetch
     connector._update_vehicle(VIN)
     assert VIN in connector._bootstrapped
-    assert fake.download_count == 2
+    assert fake.download_count == 1
 
-    # Second call: only normal fetch = 1 download
+    # Second call: newest dataset already in _last_dataset, no download
     connector._update_vehicle(VIN)
-    assert fake.download_count == 3
+    assert fake.download_count == 1


### PR DESCRIPTION
At startup, I noticed that only the deltas are propagated, so at startup it's helpfull to fetch all ZIPs so we have a better init state

- implement dataset merging (keeps latest datapoint per field_name)
- bootstrap functionality for vehicles (fetch all reports, and merge for better initialize state)
- Connector has a known_mapped_fields with all carconnectivity fields

Added test for this functionality