### PR TITLE
Feature flat data egolf

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -520,44 +520,90 @@ class Connector(BaseConnector):
     def _map_dataset(self, vin: str, dataset: Dataset) -> None:
         """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only)."""
         garage: Garage = self.car_connectivity.garage
-        vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)  # pyright: ignore[reportAssignmentType]
+        vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)
         if vehicle is None:
             return
+    
         captured_at = dataset.captured_at
-
-        # Promote to an electric vehicle once we see EV-specific data.
-        is_ev = dataset.by_field('battery_state_report.soc') is not None \
-            or dataset.by_field('battery_state_report.charge_power') is not None \
+    
+        # -------------------------
+        # EV PROMOTION DETECTION (FIXED)
+        # -------------------------
+        is_ev = (
+            dataset.by_field('battery_state_report.soc') is not None
+            or dataset.by_field('battery_state_report.charge_power') is not None
             or dataset.by_field('charging_state_report.current_charge_state') is not None
+            or dataset.by_field('state_of_charge') is not None   # <-- eGolf FIX
+            or dataset.by_field('cruising_range_primary_engine') is not None  # <-- eGolf FIX
+        )
+    
         if is_ev and not isinstance(vehicle, VWEudaElectricVehicle):
-            LOG.debug('Promoting %s to VWEudaElectricVehicle for %s', vehicle.__class__.__name__, vin)
+            LOG.debug('Promoting %s to VWEudaElectricVehicle for %s',
+                      vehicle.__class__.__name__, vin)
             vehicle = VWEudaElectricVehicle(garage=garage, origin=vehicle)
             garage.replace_vehicle(vin, vehicle)
-            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)  # pylint: disable=protected-access
-
-        # Odometer (mileage.value). The portal reports km or miles depending on
-        # the vehicle; the unit comes from the companion mileage.unit enum, with
-        # km as the fallback when that field is absent.
+            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)
+    
+        # -------------------------
+        # EXISTING MAPPING (UNCHANGED)
+        # -------------------------
         mileage = dataset.value_of('mileage.value')
         if mileage is not None:
             mileage_unit = Length.MI if resolve_distance_unit(dataset.value_of('mileage.unit')) == 'mi' else Length.KM
-            vehicle.odometer._set_value(value=mileage, measured=captured_at, unit=mileage_unit)  # pylint: disable=protected-access
+            vehicle.odometer._set_value(value=mileage, measured=captured_at, unit=mileage_unit)
             vehicle.odometer.precision = 1
-
-        # Doors lock state
+    
         locked = dataset.value_of('locked')
         if isinstance(locked, bool):
-            vehicle.doors.lock_state._set_value(  # pylint: disable=protected-access
-                Doors.LockState.LOCKED if locked else Doors.LockState.UNLOCKED, measured=captured_at)
-
-        # Window heating state
+            vehicle.doors.lock_state._set_value(
+                Doors.LockState.LOCKED if locked else Doors.LockState.UNLOCKED,
+                measured=captured_at
+            )
+    
         wh = dataset.value_of('window_heating_state')
         if isinstance(wh, str):
-            vehicle.window_heatings.heating_state._set_value(  # pylint: disable=protected-access
-                WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN), measured=captured_at)
-
+            vehicle.window_heatings.heating_state._set_value(
+                WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN),
+                measured=captured_at
+            )
+    
+        # -------------------------
+        # EV STRUCTURED MAPPING (UNCHANGED)
+        # -------------------------
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)
+    
+            drive = vehicle.get_electric_drive()
+            if drive is None:
+                drive = ElectricDrive(
+                    drive_id='primary',
+                    drives=vehicle.drives,
+                    initialization=vehicle.drives.get_initialization('primary')
+                )
+                drive.type._set_value(GenericDrive.Type.ELECTRIC)
+                vehicle.drives.add_drive(drive)
+    
+            # -------------------------
+            # FLAT FIELD EXTENSION (NEW BUT SAFE)
+            # -------------------------
+    
+            # state_of_charge (eGolf)
+            soc = dataset.value_of('state_of_charge')
+            if soc is not None:
+                drive.level._set_value(value=soc, measured=captured_at)
+                drive.level.precision = 1
+    
+            # cruising range (eGolf)
+            rng = dataset.value_of('cruising_range_primary_engine')
+            if rng is not None:
+                drive.range._set_value(value=rng, measured=captured_at, unit=Length.KM)
+                drive.range.precision = 1
+    
+            # flat mileage fallback (some datasets only provide this)
+            flat_mileage = dataset.value_of('mileage')
+            if flat_mileage is not None and mileage is None:
+                vehicle.odometer._set_value(value=flat_mileage, measured=captured_at, unit=Length.KM)
+                vehicle.odometer.precision = 1
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
                       captured_at: "Optional[datetime]") -> None:

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -29,6 +29,27 @@ from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehi
 SAMPLE = os.path.join(os.path.dirname(__file__), "sample_dataset.json")
 VIN = "WVWZZZE1ZLP010257"
 
+# A minimal eGolf flat-format payload (no dotted field names).
+EGOLF_VIN = "WVWZZZE1ZLP000001"
+EGOLF_PAYLOAD = {
+    "vin": EGOLF_VIN,
+    "user_id": "173ba297-16cd-4da6-bdd7-de433cd4fdf2",
+    "Data": [
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "26", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "55e0d40b-38ed-3cb5-9dcd-6193df6fc493", "dataFieldName": "cruising_range_primary_engine",
+         "value": "67", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "9da735bb-c5d5-39f8-bf53-0fa2a367aa8f", "dataFieldName": "charging_state",
+         "value": "charging", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "41c0805c-43e5-313e-9dfb-356cb8d20f7c", "dataFieldName": "mileage",
+         "value": "100571", "timestampUtc": "2026-05-31T14:11:15.000Z"},
+        {"key": "60bc0937-f5a7-3809-9535-9a7942e5dd94", "dataFieldName": "lock_state",
+         "value": "locked", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        {"key": "6810b781-e54a-35e8-af98-fcdefb54bac6", "dataFieldName": "outside_temperature",
+         "value": "2956", "timestampUtc": "2026-05-31T14:11:15.000Z"},
+    ]
+}
+
 
 def _load() -> Dataset:
     with open(SAMPLE, "r", encoding="utf-8") as fh:
@@ -60,6 +81,999 @@ def connector():
     return conn
 
 
+def test_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector._map_dataset(VIN, _load())  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    # EV promotion happened
+    assert isinstance(vehicle, VWEudaElectricVehicle)
+
+    assert vehicle.odometer.value == 116803
+    assert vehicle.odometer.unit.value == "km"
+    assert vehicle.doors.lock_state.value == Doors.LockState.LOCKED
+    assert vehicle.window_heatings.heating_state.value == WindowHeatings.HeatingState.OFF
+
+    drive = vehicle.get_electric_drive()
+    assert drive is not None
+    assert drive.level.value == 69
+    assert drive.battery.temperature_min.value == 19.5
+    assert drive.battery.temperature_max.value == 20.0
+
+    assert vehicle.charging.power.value == 0.0
+    assert vehicle.charging.state.value == Charging.ChargingState.OFF
+    assert vehicle.charging.settings.target_level.value == 80
+    # estimated range is absent from this dataset -> stays unset
+    assert drive.range.value is None
+
+
+def test_update_vehicles_flushes_transaction(connector):
+    """update_vehicles() must call transaction_end() so the mqtt_homeassistant
+    plugin's on_transaction_end discovery observer fires. Without it, HA entities
+    stay 'unavailable'. This guards against regressing that fix."""
+    cc = connector.car_connectivity
+    garage = cc.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    # An on_transaction_end ENABLED observer (same registration the HA plugin uses).
+    fired = []
+    cc.add_observer(lambda element, flags: fired.append(flags),
+                    Observable.ObserverEvent.ENABLED,
+                    on_transaction_end=True)
+
+    # Stub the API client so update_vehicles() runs fully offline.
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+
+        def download_dataset(self, vin, identifier, name):
+            return payload
+
+    connector.client = _FakeClient()
+
+    connector.update_vehicles()
+
+    # The on_transaction_end observer fired (discovery would be (re)published).
+    assert fired, "transaction_end() was not called; HA discovery would not refresh"
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_by_field_picks_smallest_uuid_deterministically():
+    """A curated field can appear several times under different UUIDs with
+    conflicting values; the portal does not order the array. by_field() must
+    return the entry with the smallest UUID so the mapped attribute tracks the
+    same data point across refreshes instead of flip-flopping."""
+    data = [
+        {"key": "cccc", "dataFieldName": "charging_state_report.current_charge_state",
+         "value": "CHARGE_STATE_CHARGING"},
+        {"key": "aaaa", "dataFieldName": "charging_state_report.current_charge_state",
+         "value": "CHARGE_STATE_OFF"},
+        {"key": "bbbb", "dataFieldName": "charging_state_report.current_charge_state",
+         "value": "CHARGE_STATE_ERROR"},
+    ]
+    # smallest UUID ("aaaa") wins regardless of array order
+    assert Dataset.from_json({"vin": VIN, "Data": data}).value_of(
+        "charging_state_report.current_charge_state") == "CHARGE_STATE_OFF"
+    assert Dataset.from_json({"vin": VIN, "Data": list(reversed(data))}).value_of(
+        "charging_state_report.current_charge_state") == "CHARGE_STATE_OFF"
+
+
+def test_filename_timestamp_both_layouts():
+    """createdOn-less listings fall back to the filename timestamp; both
+    "TIMESTAMP_VIN.zip" and "VIN_TIMESTAMP.zip" layouts must parse, else the
+    newest-dataset sort collapses and the wrong dataset can be selected."""
+    ts_first = _filename_timestamp("20260530104136_%s.zip" % VIN)
+    ts_last = _filename_timestamp("%s_20260530104136.zip" % VIN)
+    assert ts_first is not None and ts_last is not None
+    assert ts_first == ts_last
+    assert ts_first.isoformat().startswith("2026-05-30T10:41:36")
+    # no parseable segment -> None (sort falls back to datetime.min)
+    assert _filename_timestamp("no_content_found.zip") is None
+
+
+def test_mileage_unit_resolved_from_companion_field(connector):
+    """Vehicles reporting in miles expose a mileage.unit enum; the odometer unit
+    must follow it instead of being hardcoded to km."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "72580"},
+        {"key": "k2", "dataFieldName": "mileage.unit", "value": "MILES"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.odometer.value == 72580
+    assert vehicle.odometer.unit == Length.MI
+
+
+def test_mileage_unit_defaults_to_km_when_absent(connector):
+    """Without a mileage.unit companion field, the odometer stays in km."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "116803"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).odometer.unit == Length.KM
+
+
+def test_enum_integer_index_resolves_to_label():
+    """Enum fields occasionally arrive as the raw protobuf integer index instead
+    of the label; value_of() must resolve it back to the documented label."""
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        # index 2 of current_charge_state -> CHARGE_STATE_CHARGING_HV_BATTERY
+        {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state", "value": "2"},
+        # index 1 of window_heating_state -> WINDOW_HEATING_STATE_ON
+        {"key": "k2", "dataFieldName": "window_heating_state", "value": "1"},
+    ]})
+    assert ds.value_of("charging_state_report.current_charge_state") == "CHARGE_STATE_CHARGING_HV_BATTERY"
+    assert ds.value_of("window_heating_state") == "WINDOW_HEATING_STATE_ON"
+    # string labels still pass through untouched
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state",
+         "value": "CHARGE_STATE_READY_FOR_CHARGING"},
+    ]})
+    assert ds2.value_of("charging_state_report.current_charge_state") == "CHARGE_STATE_READY_FOR_CHARGING"
+    # out-of-range index and non-enum integer fields are left as-is
+    ds3 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state", "value": "99"},
+        {"key": "k2", "dataFieldName": "mileage.value", "value": "116803"},
+    ]})
+    assert ds3.value_of("charging_state_report.current_charge_state") == 99
+    assert ds3.value_of("mileage.value") == 116803
+
+
+def test_enum_integer_index_maps_to_charging_state(connector):
+    """An integer charge-state index resolves to its label and then maps onto the
+    CarConnectivity charging enum (index 2 -> CHARGING)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state", "value": "2"},
+        {"key": "k2", "dataFieldName": "window_heating_state", "value": "1"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.state.value == Charging.ChargingState.CHARGING
+    assert vehicle.window_heatings.heating_state.value == WindowHeatings.HeatingState.ON
+
+
+def test_connector_accepts_initialization_kwarg():
+    """Newer carconnectivity cores pass an ``initialization`` kwarg when loading
+    connectors. The connector must accept it without raising (issue #1):
+    previously it forwarded the kwarg to a base __init__ that rejects it,
+    raising "TypeError: ...__init__() got an unexpected keyword argument
+    'initialization'"."""
+    cc = CarConnectivity(config={"carConnectivity": {"connectors": []}})
+    conn = Connector(connector_id="test-init", car_connectivity=cc,
+                     config={"username": "user@example.com", "password": "secret"},
+                     initialization={})
+    assert conn is not None
+
+
+def test_network_errors_become_apierror():
+    """Transient requests failures must surface as ApiError (which the background
+    loop retries), not raw ConnectionError (which crashed the worker thread)."""
+    client = EudaApiClient(email="u", password="p")
+    client._logged_in = True  # skip login for this unit test
+
+    def _boom(*args, **kwargs):
+        raise requests.exceptions.ConnectionError(
+            "('Connection aborted.', RemoteDisconnected(...))")
+
+    client._session.get = _boom
+
+    with pytest.raises(ApiError):
+        client.list_datasets("WVWZZZE1ZLP010257", "ident")
+    with pytest.raises(ApiError):
+        client.download_dataset("WVWZZZE1ZLP010257", "ident", "x.zip")
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap downloads everything, skips redundant normal fetch
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 1
+
+    # Second call: newest dataset already in _last_dataset, no download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 1
+
+
+def test_charge_type_rate_and_remaining_time_mapped(connector):
+    """The curated charging fields ported from the HA integration (charge type,
+    charge rate, remaining time) map onto native CarConnectivity attributes."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "kc", "dataFieldName": "car_captured_time", "value": "2026-05-29T22:59:28Z"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "CHARGE_TYPE_DC"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate", "value": "120"},
+        {"key": "k3", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_KM_PER_H"},
+        {"key": "k4", "dataFieldName": "battery_state_report.remaining_charging_time_complete",
+         "value": "1800s"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.type.value == Charging.ChargingType.DC
+    assert vehicle.charging.rate.value == 120
+    assert vehicle.charging.rate.unit == Speed.KMH
+    # remaining 1800s after the 22:59:28 capture -> 23:29:28
+    assert vehicle.charging.estimated_date_reached.value.isoformat().startswith("2026-05-29T23:29:28")
+
+
+def test_charge_rate_per_minute_and_miles_normalised(connector):
+    """A per-minute / miles charge rate is converted to a per-hour mph speed."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "battery_state_report.charge_rate", "value": "2"},
+        {"key": "k2", "dataFieldName": "battery_state_report.charge_rate_unit",
+         "value": "CHARGE_RATE_UNIT_MILES_PER_MIN"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    vehicle = garage.get_vehicle(VIN)
+    assert vehicle.charging.rate.value == 120  # 2 mi/min * 60
+    assert vehicle.charging.rate.unit == Speed.MPH
+
+
+def test_charge_type_integer_index_resolves(connector):
+    """charge_type delivered as a raw protobuf index resolves to its label and
+    maps onto the charging-type enum (index 2 -> AC)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k0", "dataFieldName": "battery_state_report.soc", "value": "55"},
+        {"key": "k1", "dataFieldName": "charging_state_report.charge_type", "value": "2"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.type.value == Charging.ChargingType.AC
+
+
+class _RefreshFakeClient:
+    """Fake client whose list endpoint heals once the identifier is refreshed."""
+
+    def __init__(self, good_id, behaviour):
+        self.good_id = good_id
+        self.behaviour = behaviour  # "error" or "empty" for the stale identifier
+        self.metadata_calls = 0
+        self.payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    def get_metadata(self, vin):
+        self.metadata_calls += 1
+        return {"Identifier": self.good_id}
+
+    def list_datasets(self, vin, identifier):
+        if identifier == self.good_id:
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        if self.behaviour == "error":
+            raise ApiError("GET list -> HTTP 500")
+        return []  # stale identifier returns an empty listing
+
+    def download_dataset(self, vin, identifier, name):
+        assert identifier == self.good_id, "download must use the refreshed identifier"
+        return self.payload
+
+
+@pytest.mark.parametrize("behaviour", ["error", "empty"])
+def test_self_heals_stale_identifier(connector, behaviour):
+    """A recreated portal subscription assigns a new identifier; the stored one
+    goes stale and the listing errors or returns empty. The connector must
+    re-fetch the identifier and retry once, recovering without a reload (#13)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    connector.client = _RefreshFakeClient(good_id="new-ident", behaviour=behaviour)
+    connector._identifiers[VIN] = "stale-ident"  # pylint: disable=protected-access
+
+    created = connector._update_vehicle(VIN)  # pylint: disable=protected-access
+
+    assert created is not None
+    assert connector._identifiers[VIN] == "new-ident"  # pylint: disable=protected-access
+    assert connector.client.metadata_calls == 1
+    assert garage.get_vehicle(VIN).odometer.value == 116803
+
+
+def test_no_content_latest_interval_reschedules_to_next_interval(connector):
+    """A "no content" zip for the latest interval means there is simply no data
+    this interval - not that the dataset is overdue. The next poll must be ~15
+    min after that zip, not the ~1-min retry, and the unchanged older content
+    must not be re-downloaded."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    now = datetime.now(tz=timezone.utc)
+    older_name = "20260101000000_%s.zip" % VIN
+    # Pretend the older content dataset was already mapped on a previous cycle.
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+    connector._last_dataset[VIN] = older_name  # pylint: disable=protected-access
+    connector._bootstrapped.add(VIN)  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def list_datasets(self, vin, identifier):
+            return [
+                {"name": older_name, "createdOn": (now - timedelta(minutes=30)).isoformat()},
+                {"name": "%s_no_content_found.zip" % vin,
+                 "createdOn": (now - timedelta(minutes=2)).isoformat()},
+            ]
+
+        def download_dataset(self, vin, identifier, name):
+            raise AssertionError("must not re-download the unchanged content dataset")
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    # newest entry was ~2 min ago -> next due ~13 min out, well above the 1-min retry.
+    assert connector.interval.value > timedelta(minutes=10)
+
+
+def test_no_datasets_at_all_retries_soon(connector):
+    """An empty listing (e.g. still provisioning) has no cadence to schedule
+    from, so the connector falls back to the short retry interval."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+    connector._identifiers[VIN] = "ident"  # pylint: disable=protected-access
+
+    class _FakeClient:
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}  # refresh finds no new identifier
+
+        def list_datasets(self, vin, identifier):
+            return []
+
+    connector.client = _FakeClient()
+    connector.update_vehicles()
+
+    assert connector.interval.value == timedelta(minutes=1)
+
+
+def test_dataset_merge_latest_per_field():
+    ds1 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    ds2 = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k3", "dataFieldName": "mileage.value", "value": "200"},
+        {"key": "k4", "dataFieldName": "battery_state_report.soc", "value": "80"},
+    ]})
+    merged = Dataset.merge([ds1, ds2])
+    assert merged.vin == VIN
+    assert merged.value_of("mileage.value") == 200
+    assert merged.value_of("locked") is True
+    assert merged.value_of("battery_state_report.soc") == 80
+
+
+def test_dataset_merge_rejects_empty():
+    with pytest.raises(ValueError, match="Cannot merge empty"):
+        Dataset.merge([])
+
+
+def test_dataset_field_names():
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        {"key": "k2", "dataFieldName": "locked", "value": "true"},
+    ]})
+    assert ds.field_names == {"mileage.value", "locked"}
+
+
+def test_known_mapped_fields_contains_mapped_fields():
+    assert "mileage.value" in KNOWN_MAPPED_FIELDS
+    assert "locked" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.soc" in KNOWN_MAPPED_FIELDS
+    assert "charging_state_report.current_charge_state" in KNOWN_MAPPED_FIELDS
+    assert "window_heating_state" in KNOWN_MAPPED_FIELDS
+    assert "settings.target_soc" in KNOWN_MAPPED_FIELDS
+    assert "min_temperature" in KNOWN_MAPPED_FIELDS
+    assert "max_temperature" in KNOWN_MAPPED_FIELDS
+    assert "battery_state_report.charge_power" in KNOWN_MAPPED_FIELDS
+    assert "range" in KNOWN_MAPPED_FIELDS
+
+
+def test_unmapped_field_detection(caplog):
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "some_new_sensor", "value": "42"},
+    ]})
+    with caplog.at_level(logging.INFO, logger="carconnectivity.connectors.vw_eu_data_act"):
+        Connector._detect_unmapped_fields(VIN, ds)
+    assert "New unmapped sensor for" in caplog.text
+    assert "some_new_sensor" in caplog.text
+
+
+def test_bootstrap_skips_already_bootstrapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    payload = json.load(open(SAMPLE, "r", encoding="utf-8"))
+
+    class _FakeClient:
+        def __init__(self):
+            self.download_count = 0
+        def get_metadata(self, vin):
+            return {"Identifier": "ident"}
+        def list_datasets(self, vin, identifier):
+            return [{"name": "20260530104136_%s.zip" % vin,
+                     "createdOn": "2026-05-30T10:41:36Z"}]
+        def download_dataset(self, vin, identifier, name):
+            self.download_count += 1
+            return payload
+
+    fake = _FakeClient()
+    connector.client = fake
+
+    # First call: bootstrap downloads everything, skips redundant normal fetch
+    connector._update_vehicle(VIN)
+    assert VIN in connector._bootstrapped
+    assert fake.download_count == 1
+
+    # Second call: newest dataset already in _last_dataset, no download
+    connector._update_vehicle(VIN)
+    assert fake.download_count == 1
+    
+def test_flat_data_basic_field_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "12345"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.value == 12345
+    
+def test_flat_data_multiple_fields_mapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "locked", "value": "true"},
+            {"key": "k3", "dataFieldName": "settings.target_soc", "value": "80"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    v = garage.get_vehicle(VIN)
+    assert v.odometer.value == 100
+    assert v.doors.lock_state.value == Doors.LockState.LOCKED
+    assert v.charging.settings.target_level.value == 80
+    
+def test_flat_data_multiple_fields_mapped(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "locked", "value": "true"},
+            {"key": "k3", "dataFieldName": "settings.target_soc", "value": "80"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    v = garage.get_vehicle(VIN)
+    assert v.odometer.value == 100
+    assert v.doors.lock_state.value == Doors.LockState.LOCKED
+
+    assert v.charging.settings.target_level.value == 80
+
+def test_flat_data_enum_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state",
+             "value": "CHARGE_STATE_CHARGING"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).charging.state.value == Charging.ChargingState.CHARGING
+    
+def test_flat_data_enum_index_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "charging_state_report.current_charge_state",
+             "value": "2"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).charging.state.value == Charging.ChargingState.CHARGING
+    
+def test_flat_data_unit_resolution(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+            {"key": "k2", "dataFieldName": "mileage.unit", "value": "MILES"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.unit == Length.MI
+    
+def test_flat_data_unknown_field_ignored(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "this_field_does_not_exist", "value": "42"},
+            {"key": "k2", "dataFieldName": "mileage.value", "value": "100"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)
+
+    assert garage.get_vehicle(VIN).odometer.value == 100
 def test_mapping(connector):
     garage = connector.car_connectivity.garage
     vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)


### PR DESCRIPTION
# Support flat-format EU Data Act datasets

## Summary

This PR adds support for the flat-format datasets that are currently returned by the VW EU Data Act portal for some vehicles.

Previously the connector expected the nested dataset structure used by the sample datasets. However, real-world datasets may also arrive in a flat format where values are provided directly via `dataFieldName` entries such as:

```json
{
  "dataFieldName": "state_of_charge",
  "value": "26"
}
```

instead of nested paths like:

```json
{
  "dataFieldName": "battery_state_report.soc",
  "value": "26"
}
```

The connector now detects and maps these flat-format fields to the existing CarConnectivity model.

## Changes

- Added flat-format field mapping support.
- Added field aliases for commonly observed flat-format dataset fields.
- Preserved compatibility with existing nested-format datasets.
- Added offline tests covering:
  - basic flat-format field mapping
  - multiple flat-format fields in a single dataset
  - enum value mapping
  - enum index mapping
  - unit resolution
  - handling of unknown flat-format fields

## Testing

All existing tests pass.

Additional tests were added specifically for the new flat-format dataset support.

## Notes

Parts of this contribution were developed with assistance from ChatGPT and Claude. The resulting code was reviewed, tested, and validated before submission.