### PR TITLE
fix(dataset): select the freshest reading by timestampUtc, not smallest UUID

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -202,6 +202,7 @@ class DataPoint:
     key: str
     field_name: str
     raw_value: str
+    timestamp: Optional[datetime] = None  # the field's own timestampUtc (when the car reported it)
 
     @property
     def value(self):
@@ -212,6 +213,30 @@ class DataPoint:
         mapping (which keys off the label string) keeps working.
         """
         return resolve_enum_index(self.field_name, parse_value(self.raw_value))
+
+
+def _freshness_key(dp: "DataPoint"):
+    """Sort key for ``min()`` that picks the freshest data point.
+
+    Orders timestamped points ahead of timestamp-less ones, newest first, with
+    the smallest UUID as a stable tie-break (so selection never flip-flops when
+    the portal reshuffles the array or two readings share a timestamp).
+    """
+    if dp.timestamp is not None:
+        return (0, -dp.timestamp.timestamp(), dp.key)
+    return (1, 0.0, dp.key)
+
+
+def _at_least_as_fresh(new: "DataPoint", cur: "DataPoint") -> bool:
+    """Whether ``new`` should replace ``cur`` while merging datasets in list order.
+
+    A timestamped reading wins over an older or timestamp-less one; on equal
+    timestamps (or when both lack one) the later dataset in list order wins,
+    preserving the previous behaviour for fields that carry no ``timestampUtc``.
+    """
+    if new.timestamp is not None:
+        return cur.timestamp is None or new.timestamp >= cur.timestamp
+    return cur.timestamp is None
 
 
 @dataclass
@@ -233,7 +258,8 @@ class Dataset:
             if not key:
                 continue
             field_name = item.get("dataFieldName") or key
-            dp = DataPoint(key=key, field_name=field_name, raw_value=item.get("value", ""))
+            dp = DataPoint(key=key, field_name=field_name, raw_value=item.get("value", ""),
+                           timestamp=parse_timestamp(item.get("timestampUtc")))
             points[key] = dp
             if field_name == "car_captured_time":
                 ts = parse_timestamp(dp.raw_value)
@@ -257,7 +283,10 @@ class Dataset:
         for ds in datasets:
             for field_name in ds.field_names:
                 dp = ds.by_field(field_name)
-                if dp is not None:
+                if dp is None:
+                    continue
+                cur = latest.get(field_name)
+                if cur is None or _at_least_as_fresh(dp, cur):
                     latest[field_name] = dp
             if ds.captured_at and (merged_captured is None or ds.captured_at > merged_captured):
                 merged_captured = ds.captured_at
@@ -272,13 +301,15 @@ class Dataset:
         The portal merges several report snapshots into one flat array with no
         ordering guarantee and no way to tell which value is "live", so a field
         like ``charging_state_report.current_charge_state`` can appear several
-        times under different UUIDs with conflicting values. We pick the entry
-        with the smallest ``key`` (UUID): an arbitrary but *stable* choice, so a
-        mapped attribute consistently tracks the same data point across refreshes
-        instead of flip-flopping when the portal reshuffles the array.
+        times under different UUIDs with conflicting values. We pick the
+        **freshest** reading (latest ``timestampUtc``); when timestamps are equal
+        or absent we fall back to the smallest ``key`` (UUID): an arbitrary but
+        *stable* choice, so a mapped attribute consistently tracks the same data
+        point across refreshes instead of flip-flopping when the portal reshuffles
+        the array.
         """
         matches = [dp for dp in self.points.values() if dp.field_name == field_name]
-        return min(matches, key=lambda dp: dp.key) if matches else None
+        return min(matches, key=_freshness_key) if matches else None
 
     def value_of(self, field_name: str):
         """Return the typed value of ``field_name`` or ``None`` if absent."""

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -280,6 +280,47 @@ def test_by_field_picks_smallest_uuid_deterministically():
         "charging_state_report.current_charge_state") == "CHARGE_STATE_OFF"
 
 
+def test_by_field_prefers_freshest_timestamp():
+    """When a field appears several times, the reading with the latest
+    timestampUtc wins, even if a staler reading has a smaller UUID (which the
+    old smallest-UUID rule would have picked)."""
+    data = [
+        {"key": "aaaa", "dataFieldName": "oil_level_actual_level",
+         "value": "100.0", "timestampUtc": "2026-06-23T15:14:12.000Z"},
+        {"key": "zzzz", "dataFieldName": "oil_level_actual_level",
+         "value": "87.5", "timestampUtc": "2026-06-25T10:37:14.000Z"},
+    ]
+    assert Dataset.from_json({"vin": VIN, "Data": data}).value_of("oil_level_actual_level") == 87.5
+
+
+def test_merge_prefers_freshest_timestamp_regardless_of_list_order():
+    """A stale reading in a later-listed dataset must not override a fresher one.
+    Reproduces the oil-level bug: oil 100.0 measured 2026-06-23 must lose to oil
+    87.5 measured 2026-06-25 whatever the merge order."""
+    fresh = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "oil_level_actual_level",
+         "value": "87.5", "timestampUtc": "2026-06-25T10:37:14.000Z"},
+    ]})
+    stale = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k2", "dataFieldName": "oil_level_actual_level",
+         "value": "100.0", "timestampUtc": "2026-06-23T15:14:12.000Z"},
+    ]})
+    assert Dataset.merge([fresh, stale]).value_of("oil_level_actual_level") == 87.5
+    assert Dataset.merge([stale, fresh]).value_of("oil_level_actual_level") == 87.5
+
+
+def test_merge_timestampless_field_keeps_list_order():
+    """Fields without timestampUtc keep the previous behaviour: the later dataset
+    in list order wins (no regression for timestamp-less fields)."""
+    first = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "charging_state", "value": "off"},
+    ]})
+    second = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k2", "dataFieldName": "charging_state", "value": "charging"},
+    ]})
+    assert Dataset.merge([first, second]).value_of("charging_state") == "charging"
+
+
 def test_filename_timestamp_both_layouts():
     """createdOn-less listings fall back to the filename timestamp; both
     "TIMESTAMP_VIN.zip" and "VIN_TIMESTAMP.zip" layouts must parse, else the


### PR DESCRIPTION
## Summary

A portal field can appear several times across the merged snapshots, and the
array has no ordering guarantee. `by_field` picked the **smallest UUID** and
`merge` kept the **last dataset in list order** — both recency-blind.

For a *latched* field such as `oil_level_actual_level` (the car re-measures only
occasionally, so the value persists across many 15-min publishes) this can
surface a **stale** value: e.g. oil `100.0` measured 2026-06-23 winning over the
current `87.5` measured 2026-06-25.

## Fix

- Capture each data point's `timestampUtc`.
- `by_field` and `merge` now prefer the reading with the **latest** `timestampUtc`.
- Fall back to the smallest UUID / list order only when timestamps are equal or
  absent — so timestamp-less fields keep their previous behaviour and selection
  stays stable (no flip-flopping).

## Tests

- Freshest timestamp wins even when the staler reading has a smaller UUID.
- Merge picks the freshest regardless of dataset order (reproduces the oil bug).
- Timestamp-less fields keep list-order behaviour.
- The existing smallest-UUID determinism test still passes.

Standalone fix — independent of the multi-brand/PHEV and oil-mapping PRs.