### PR TITLE
feat(vw_eu_data_act): per-vehicle dataset freshness (captured_at)

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -606,7 +606,7 @@ class Connector(BaseConnector):
         if self._last_dataset.get(vin) != newest['name']:
             payload = self.client.download_dataset(vin, identifier, newest['name'])
             dataset = Dataset.from_json(payload)
-            self._map_dataset(vin, dataset)
+            self._map_dataset(vin, dataset, _created_on(newest))
             self._last_dataset[vin] = newest['name']
         return newest_created
 
@@ -632,7 +632,7 @@ class Connector(BaseConnector):
         self._merged_datasets[vin] = merged
         self._observed_fields[vin] = set(merged.field_names)
         self._detect_unmapped_fields(vin, merged)
-        self._map_dataset(vin, merged)
+        self._map_dataset(vin, merged, _created_on(listing[-1]) if listing else None)
         self._bootstrapped.add(vin)
         LOG.info('Bootstrapped vehicle %s: merged %d datasets, %d unique fields',
                  vin, len(datasets), len(merged.field_names))
@@ -648,8 +648,11 @@ class Connector(BaseConnector):
 
     # -- mapping -----------------------------------------------------------
 
-    def _map_dataset(self, vin: str, dataset: Dataset) -> None:
-        """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only)."""
+    def _map_dataset(self, vin: str, dataset: Dataset, created_on: Optional[datetime] = None) -> None:
+        """Map an EU Data Act dataset onto native CarConnectivity attributes (read-only).
+
+        ``created_on`` is the portal createdOn of the mapped dataset, used as the
+        freshness fallback when the data format carries no per-field timestampUtc."""
         garage: Garage = self.car_connectivity.garage
         vehicle: Optional[VWEudaVehicle] = garage.get_vehicle(vin)  # pyright: ignore[reportAssignmentType]
         if vehicle is None:
@@ -703,13 +706,16 @@ class Connector(BaseConnector):
         # (re)created lazily on the current instance because the promotion above swaps
         # in a subclass that does not carry custom attributes over. The base MQTT
         # plugin auto-publishes it, so it can back a `device_class: timestamp` sensor.
-        if captured_at is not None:
+        # Prefer the precise per-measurement time (max timestampUtc); fall back to the
+        # dataset's createdOn when the portal format carries no field timestamps.
+        freshness = captured_at or created_on
+        if freshness is not None:
             cap_attr = getattr(vehicle, 'captured_at', None)
             if not isinstance(cap_attr, DateAttribute):
                 cap_attr = DateAttribute(name='captured_at', parent=vehicle, tags={'connector_custom'})
                 vehicle.captured_at = cap_attr
-            if cap_attr.value is None or captured_at > cap_attr.value:
-                cap_attr._set_value(value=captured_at)  # pylint: disable=protected-access
+            if cap_attr.value is None or freshness > cap_attr.value:
+                cap_attr._set_value(value=freshness)  # pylint: disable=protected-access
 
         # Odometer (mileage.value). The portal reports km or miles depending on
         # the vehicle; the unit comes from the companion mileage.unit enum, with

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta, timezone
 from carconnectivity.errors import AuthenticationError, RetrievalError, TooManyRequestsError
 from carconnectivity.util import config_remove_credentials
 from carconnectivity.units import EnergyConsumption, FuelConsumption, Length, Power, Speed, Temperature
-from carconnectivity.attributes import DurationAttribute, EnumAttribute
+from carconnectivity.attributes import DateAttribute, DurationAttribute, EnumAttribute
 from carconnectivity.vehicle import GenericVehicle, ElectricVehicle, CombustionVehicle
 from carconnectivity.drive import CombustionDrive, DieselDrive, ElectricDrive, GenericDrive
 from carconnectivity.battery import Battery
@@ -697,6 +697,19 @@ class Connector(BaseConnector):
             garage.replace_vehicle(vin, vehicle)
             vehicle.type._set_value(desired_type)  # pylint: disable=protected-access
         is_phev = has_electric and has_fuel
+
+        # Dataset freshness, exposed PER VEHICLE: one connector serves several VINs,
+        # each with its own capture time, so this cannot live on the connector. It is
+        # (re)created lazily on the current instance because the promotion above swaps
+        # in a subclass that does not carry custom attributes over. The base MQTT
+        # plugin auto-publishes it, so it can back a `device_class: timestamp` sensor.
+        if captured_at is not None:
+            cap_attr = getattr(vehicle, 'captured_at', None)
+            if not isinstance(cap_attr, DateAttribute):
+                cap_attr = DateAttribute(name='captured_at', parent=vehicle, tags={'connector_custom'})
+                vehicle.captured_at = cap_attr
+            if cap_attr.value is None or captured_at > cap_attr.value:
+                cap_attr._set_value(value=captured_at)  # pylint: disable=protected-access
 
         # Odometer (mileage.value). The portal reports km or miles depending on
         # the vehicle; the unit comes from the companion mileage.unit enum, with


### PR DESCRIPTION
## What
Exposes the EU Data Act dataset freshness as a per-vehicle `captured_at` `DateAttribute` (when the downloaded dataset was actually captured), distinct from `last_update` (the poll time). A single connector serves several VINs, so it lives on the vehicle.

Freshness source, in order: max per-field `timestampUtc` -> dataset `createdOn` -> date parsed from the ZIP filename. The base MQTT plugin auto-publishes it on `.../garage/<VIN>/captured_at`.

## Depends on
Stacked on **#16** (multi-brand-and-decode), which provides the field mapping, drivetrain promotion, `Dataset` and `dataset.captured_at` this builds on. **#16 must merge first**; until then this PR's diff includes #16's commits, after which it reduces to the two `captured_at` commits. Independent of #17 / #18 / #19.

## Home Assistant side (cross-repo)
The matching Home Assistant timestamp entity is provided **generically** by tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant#60 (publishes any vehicle-level `DateAttribute` as `device_class: timestamp`), so no connector-specific plugin change is required.