### PR TITLE
fix: map flat-format charge power and rate (deci-kW scaling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/carconnectivity-connector-vw-eu-data-act)](https://pypi.org/project/carconnectivity-connector-vw-eu-data-act/)
 
 A [CarConnectivity](https://github.com/tillsteinbach/CarConnectivity) connector that reads vehicle
-data from the **Volkswagen EU Data Act portal** (`eu-data-act.drivesomethinggreater.com`).
+data from the **VW Group EU Data Act portal** (`eu-data-act.drivesomethinggreater.com`). It supports
+every VW Group brand on the portal (Volkswagen, Audi, Škoda, SEAT, Cupra, Bentley) and models pure
+EVs, combustion and **PHEV** drivetrains.
 
 ## Why this connector exists
 
@@ -85,29 +87,114 @@ Add a connector of type `vw_eu_data_act` to your `carconnectivity.json`:
 | `username` / `password` | — | VW ID credentials. May instead be provided in `.netrc` under machine `vw_eu_data_act`. |
 | `netrc` | `~/.netrc` | Path to a netrc file (used when `username`/`password` are omitted). |
 | `interval` | `900` | Base poll interval (seconds, min 60). The connector also auto-schedules ~15 min after the newest dataset. |
-| `country` / `language` / `brand` | `si` / `sl` / `VOLKSWAGEN_PASSENGER_CARS` | OIDC `state` components. |
+| `country` / `language` / `brand` | `si` / `sl` / `VOLKSWAGEN_PASSENGER_CARS` | OIDC `state` components. Each brand authenticates with its own OIDC `client_id` — set `brand` to match your car (see below). |
 | `vin` | — | Optional. Restrict to a single VIN; otherwise all consented vehicles are used. |
 | `hide_vins` | `[]` | VINs to exclude. |
 
+### Supported brands
+
+Set `brand` to the canonical key (or a friendly alias) for your vehicle. Matching is
+case-insensitive; an unknown value falls back to Volkswagen Passenger Cars.
+
+| `brand` key | Aliases | Manufacturer |
+|---|---|---|
+| `VOLKSWAGEN_PASSENGER_CARS` | `VW`, `VOLKSWAGEN` | Volkswagen |
+| `VOLKSWAGEN_COMMERCIAL_VEHICLES` | `VWN`, `VW_COMMERCIAL` | Volkswagen Commercial Vehicles |
+| `AUDI` | | Audi |
+| `SKODA` | `ŠKODA` | Škoda |
+| `SEAT` | | SEAT |
+| `CUPRA` | | Cupra |
+| `BENTLEY` | | Bentley |
+
+### Drivetrains (EV / combustion / PHEV)
+
+The connector detects the drivetrain from the data points present (battery vs fuel) and promotes the
+vehicle to electric, combustion or hybrid accordingly, following the same conventions as the official
+`carconnectivity-connector-seatcupra`:
+
+- **Pure EV** — a single `primary` (electric) drive.
+- **PHEV** — the `primary` drive is the **combustion** engine and the `secondary` drive is the
+  **electric** one (so the petrol range is no longer assigned to the electric drive).
+
 ## Exposed data points (read-only)
 
-| EU Data Act field | CarConnectivity attribute |
-|---|---|
-| `mileage.value` | `vehicle.odometer` (km) |
-| `battery_state_report.soc` | electric `drive.level` (%) |
-| `battery_state_report.charge_power` | `vehicle.charging.power` (kW) |
-| `battery_state_report.charge_rate` *(+ `charge_rate_unit`)* | `vehicle.charging.rate` (km/h or mph) |
-| `battery_state_report.remaining_charging_time_complete` | `vehicle.charging.estimated_date_reached` |
-| `charging_state_report.current_charge_state` | `vehicle.charging.state` |
-| `charging_state_report.charge_type` | `vehicle.charging.type` (AC / DC / off) |
-| `settings.target_soc` | `vehicle.charging.settings.target_level` (%) |
-| `range` *(when present)* | electric `drive.range` (km) |
-| `min_temperature` / `max_temperature` | `battery.temperature_min` / `temperature_max` (°C) |
-| `window_heating_state` | `vehicle.window_heatings.heating_state` |
-| `locked` | `vehicle.doors.lock_state` |
+Both the dotted (nested) and flat portal field names are accepted. Drive slots follow the drivetrain
+(see *Drivetrains* above): on a PHEV the electric drive is the `secondary` slot and combustion is
+`primary`; on a pure EV the electric drive is the single `primary` slot.
 
-Fields without a native CarConnectivity home (parking brake, charge-mode options, raw diagnostics)
-are not exposed.
+### Vehicle
+
+| EU Data Act field | CarConnectivity attribute | Notes |
+|---|---|---|
+| `mileage.value` / `mileage` | `vehicle.odometer` | unit from `mileage.unit` |
+| `outside_temperature` | `vehicle.outside_temperature` | deci-Kelvin → °C |
+| `locked` / `lock_state` | `vehicle.doors.lock_state` | |
+| `open_state_*` (per door) | `vehicle.doors[*].open_state` | front/rear L/R, bonnet, tailgate |
+| `locked_state_*` (per door) | `vehicle.doors[*].lock_state` | |
+| `position_*_window_lifter` (fallback `state_*_window_lifter`) | `vehicle.windows[*].open_state` | opening % → closed / ajar / open; incl. sunroof |
+| `window_heating_state` (+ `_front` / `_rear`) | `vehicle.window_heatings` (overall + per element) | |
+| `parking_lights` | `vehicle.lights[parking].light_state` | |
+| `cruising_range_combined` | `vehicle.drives.total_range` (km) | |
+
+### Maintenance & climatisation
+
+| EU Data Act field | CarConnectivity attribute | Notes |
+|---|---|---|
+| `maintenance_interval__time_until_inspection` | `maintenance.inspection_due_at` | signed countdown → due date |
+| `maintenance_interval__time_until_oil_change` | `maintenance.oil_service_due_at` | |
+| `maintenance_interval_distance_until_*` | `maintenance.*_due_after` (km) | |
+| `remaining_climate_time` / `remaining_climatisation_time` | `climatization.estimated_date_reached` | seconds (dotted) / minutes (flat) |
+
+### Electric drive (`secondary` on PHEV, `primary` on EV)
+
+| EU Data Act field | CarConnectivity attribute | Notes |
+|---|---|---|
+| `battery_state_report.soc` / `state_of_charge` | `drive.level` (%) | |
+| `range` / `cruising_range_secondary_engine` | `drive.range` (km) | |
+| `long_term_data_average_electr_engine_consumption` | `drive.consumption` | kWh/1000km → kWh/100km |
+| `min_temperature` / `max_temperature` | `battery.temperature_min` / `temperature_max` (°C) | |
+
+### Combustion drive (`primary` on PHEV)
+
+| EU Data Act field | CarConnectivity attribute | Notes |
+|---|---|---|
+| `fuel_level_current_level` / `tank_current_level` | `drive.level` (%) | |
+| `cruising_range_primary_engine` | `drive.range` (km) | |
+| `long_term_data_average_fuel_consumption` | `drive.consumption` | L/1000km → L/100km |
+| `scr_range` | `drive.adblue_range` (km) | diesel / SCR |
+
+### Charging
+
+| EU Data Act field | CarConnectivity attribute | Notes |
+|---|---|---|
+| `battery_state_report.charge_power` | `charging.power` (kW) | |
+| `charging_state_report.current_charge_state` / `charging_state` | `charging.state` | |
+| `charging_state_report.charge_type` / `charging_mode` | `charging.type` (AC / DC / off) | |
+| `battery_state_report.charge_rate` (+ unit) | `charging.rate` (km/h or mph) | |
+| `…remaining_charging_time_complete` / `remaining_charging_time` | `charging.estimated_date_reached` | |
+| `settings.target_soc` | `charging.settings.target_level` (%) | |
+| `plug_state` | `charging.connector.connection_state` | |
+| `external_power_supply_state` | `charging.connector.external_power` | |
+
+## Not exposed (and why)
+
+These portal fields have **no native CarConnectivity model**, so they are left as the connector's
+"unmapped sensor" log entries rather than forced into an ill-fitting attribute:
+
+- **Tyre pressures** (`tyre_pressure_actual/required/differential_*`) — no tyre-pressure model.
+- **Instrument-cluster warnings** (`active_warnings_in_instrument_cluster_*`) — no warning model; the
+  value is also a latched hex bitmask that does not clear reliably.
+- **Oil level** (`oil_level_*`) — no oil model.
+- **Trip statistics** (`short_/long_term_data_*`: average speed, trip mileage, travel time,
+  recuperation, aux/gas consumption, zero-emission distance) — no trip-statistics model.
+- **"Safe" / secured states** (`safe_state_*`), `parking_brake`, `state_spoiler`,
+  `state_service_hatch`, `state_of_hood`, `bem_level`, `energy_flow` — no attribute.
+- **Exact window opening percentage** — used to derive the window `open_state` (closed / ajar / open),
+  but the `Window` model has no numeric position attribute, so the percentage itself is not stored.
+- **Raw HV SoC** (`hv_soc`) — the displayed SoC is already mapped to `drive.level`.
+- **Diagnostics / triggers** (`echo`, `trueness`, `charging_state_error_code`,
+  `window_heating_error_code`, `charging_reason_trigger`, `led_state` / `led_color`, `cng_gas_level`,
+  `fuel_level__accuracy`, …).
 
 ## License
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/brands.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/brands.py
@@ -1,0 +1,63 @@
+"""Per-brand OIDC client_id and manufacturer label for the VW Group EU Data Act portal.
+
+Every VW Group brand uses the same portal host and API paths, but a different
+OIDC ``client_id`` and a different manufacturer name. The brand key also forms
+part of the OIDC ``state`` (``country__language__BRAND``).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class Brand:
+    """A VW Group brand: its OIDC state key, client_id and manufacturer label."""
+    key: str
+    client_id: str
+    manufacturer: str
+
+
+# Shared default client_id (Volkswagen Passenger/Commercial). The SEAT/CUPRA
+# value (f85e5b69) is the shared portal default observed in the wild; a
+# SEAT-specific client_id may exist but is unverified, so the shared one is kept.
+BRANDS: Dict[str, Brand] = {
+    "VOLKSWAGEN_PASSENGER_CARS": Brand(
+        "VOLKSWAGEN_PASSENGER_CARS",
+        "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com", "Volkswagen"),
+    "VOLKSWAGEN_COMMERCIAL_VEHICLES": Brand(
+        "VOLKSWAGEN_COMMERCIAL_VEHICLES",
+        "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com", "Volkswagen Commercial Vehicles"),
+    "AUDI": Brand(
+        "AUDI", "cc29b87a-5e9a-4362-aecf-5adea6b01bbb@apps_vw-dilab_com", "Audi"),
+    "SKODA": Brand(
+        "SKODA", "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com", "Skoda"),
+    "SEAT": Brand(
+        "SEAT", "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com", "SEAT"),
+    "CUPRA": Brand(
+        "CUPRA", "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com", "Cupra"),
+    "BENTLEY": Brand(
+        "BENTLEY", "d38aac0f-3d89-4a63-8538-b75b31322c7b@apps_vw-dilab_com", "Bentley"),
+}
+
+DEFAULT_BRAND_KEY = "VOLKSWAGEN_PASSENGER_CARS"
+
+# Friendly aliases a user might type in config -> canonical brand key.
+_ALIASES: Dict[str, str] = {
+    "VW": "VOLKSWAGEN_PASSENGER_CARS",
+    "VOLKSWAGEN": "VOLKSWAGEN_PASSENGER_CARS",
+    "VWN": "VOLKSWAGEN_COMMERCIAL_VEHICLES",
+    "VW_COMMERCIAL": "VOLKSWAGEN_COMMERCIAL_VEHICLES",
+    "SKODA": "SKODA",
+    "ŠKODA": "SKODA",
+}
+
+
+def resolve_brand(brand: Optional[str]) -> Brand:
+    """Look up a :class:`Brand` by key or alias (case-insensitive).
+
+    Falls back to Volkswagen Passenger Cars for unknown/empty input.
+    """
+    key = (brand or DEFAULT_BRAND_KEY).strip().upper()
+    key = _ALIASES.get(key, key)
+    return BRANDS.get(key, BRANDS[DEFAULT_BRAND_KEY])

--- a/src/carconnectivity_connectors/vw_eu_data_act/client.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/client.py
@@ -22,6 +22,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from carconnectivity_connectors.vw_eu_data_act.brands import resolve_brand
+
 LOG: logging.Logger = logging.getLogger("carconnectivity.connectors.vw_eu_data_act-api-debug")
 
 # --- Portal / OIDC endpoints ----------------------------------------------
@@ -211,6 +213,9 @@ class EudaApiClient:
         self._email = email
         self._password = password
         self._state = f"{country}__{language}__{brand}"
+        # Each brand authenticates with its own OIDC client_id (the state alone is
+        # not enough); resolve it from the brand key, defaulting to VW.
+        self._client_id = resolve_brand(brand).client_id
         self._timeout = timeout
         self._logged_in = False
 
@@ -315,7 +320,7 @@ class EudaApiClient:
     def _build_authorize_url(self) -> str:
         """Construct the OIDC authorize URL (bypasses the broken AEM servlet)."""
         params = {
-            "client_id": OIDC_CLIENT_ID,
+            "client_id": self._client_id,
             "response_type": "code",
             "scope": OIDC_SCOPE,
             "state": self._state,

--- a/src/carconnectivity_connectors/vw_eu_data_act/client.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/client.py
@@ -212,10 +212,12 @@ class EudaApiClient:
         self._session.mount("http://", adapter)
         self._email = email
         self._password = password
-        self._state = f"{country}__{language}__{brand}"
-        # Each brand authenticates with its own OIDC client_id (the state alone is
-        # not enough); resolve it from the brand key, defaulting to VW.
-        self._client_id = resolve_brand(brand).client_id
+        # Resolve the brand once: the OIDC state needs the canonical brand key
+        # (e.g. "CUPRA"), and each brand authenticates with its own client_id
+        # (the state alone is not enough). Accepts aliases / any case.
+        resolved = resolve_brand(brand)
+        self._state = f"{country}__{language}__{resolved.key}"
+        self._client_id = resolved.client_id
         self._timeout = timeout
         self._logged_in = False
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -18,6 +18,7 @@ import os
 import threading
 import traceback
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 
 from carconnectivity.errors import AuthenticationError, RetrievalError, TooManyRequestsError
 from carconnectivity.util import config_remove_credentials
@@ -164,6 +165,7 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'charging_state_report.current_charge_state',
     'charging_state_report.charge_type',
     'settings.target_soc',
+    'settings.charge_mode_selection',
     'car_captured_time',
     # Flat-format (eGolf) fields handled in _map_dataset.
     'mileage',
@@ -180,6 +182,14 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     # Flat-format charging + consumption (mapped in _map_electric).
     'charging_state',
     'charging_mode',
+    'charge_mode_selection_options.manual',
+    'charge_mode_selection_options.timer_charging',
+    'charge_mode_selection_options.timer_charging_climatization',
+    'charge_mode_selection_options.preferred_charging_times',
+    'charge_mode_selection_options.only_own_current',
+    'charge_mode_selection_options.home_storage_charging',
+    'charge_mode_selection_options.immediate_charging',
+    'charge_mode_selection_options.immediate_discharging',
     'plug_state',
     'external_power_supply_state',
     'remaining_charging_time',
@@ -271,6 +281,96 @@ def _lock_code(value) -> "Optional[str]":
         return 'locked'
     if value == 3:
         return 'unlocked'
+    return None
+
+
+class VWEudaChargeMode(Enum):
+    """Selected charge mode reported by the portal (``charge_mode_selection``).
+
+    Read-only. The field is the *selected* charge mode (one of its values is
+    itself ``preferred_charging_times``), so the attribute is named ``charge_mode``
+    rather than "preferred". Member names/values follow the EU Data Act data
+    dictionary options and mirror the seatcupra/skoda connector enum, so consumers
+    see a consistent set across brands.
+    """
+    MANUAL = 'manual'
+    TIMER = 'timer'
+    TIMER_CHARGING_WITH_CLIMATISATION = 'timer_charging_with_climatisation'
+    PREFERRED_CHARGING_TIMES = 'preferred_charging_times'
+    ONLY_OWN_CURRENT = 'only_own_current'
+    HOME_STORAGE_CHARGING = 'home_storage_charging'
+    IMMEDIATE_CHARGING = 'immediate_charging'
+    IMMEDIATE_DISCHARGING = 'immediate_discharging'
+    OFF = 'off'
+    INVALID = 'invalid'
+    UNKNOWN = 'unknown charge mode'
+
+
+# Dotted format: a single 'settings.charge_mode_selection' value. Normalised token
+# (upper-case, optional CHARGE_MODE_SELECTION_ prefix stripped) -> enum.
+_CHARGE_MODE_TOKENS = {
+    'MANUAL': VWEudaChargeMode.MANUAL,
+    'TIMER': VWEudaChargeMode.TIMER,
+    'TIMERCHARGING': VWEudaChargeMode.TIMER,
+    'TIMER_CHARGING': VWEudaChargeMode.TIMER,
+    'IMMEDIATECHARGING': VWEudaChargeMode.IMMEDIATE_CHARGING,
+    'IMMEDIATE_CHARGING': VWEudaChargeMode.IMMEDIATE_CHARGING,
+    'TIMER_CHARGING_CLIMATIZATION': VWEudaChargeMode.TIMER_CHARGING_WITH_CLIMATISATION,
+    'TIMER_CHARGING_CLIMATISATION': VWEudaChargeMode.TIMER_CHARGING_WITH_CLIMATISATION,
+    'TIMER_CHARGING_WITH_CLIMATISATION': VWEudaChargeMode.TIMER_CHARGING_WITH_CLIMATISATION,
+    'PREFERRED_CHARGING_TIMES': VWEudaChargeMode.PREFERRED_CHARGING_TIMES,
+    'ONLY_OWN_CURRENT': VWEudaChargeMode.ONLY_OWN_CURRENT,
+    'HOME_STORAGE_CHARGING': VWEudaChargeMode.HOME_STORAGE_CHARGING,
+    'IMMEDIATE_DISCHARGING': VWEudaChargeMode.IMMEDIATE_DISCHARGING,
+    'OFF': VWEudaChargeMode.OFF,
+    'INVALID': VWEudaChargeMode.INVALID,
+}
+
+# Flat/continuous format: one boolean per option
+# (charge_mode_selection_options.<suffix>); the active one wins.
+_CHARGE_MODE_FLAT = {
+    'manual': VWEudaChargeMode.MANUAL,
+    'timer_charging': VWEudaChargeMode.TIMER,
+    'timer_charging_climatization': VWEudaChargeMode.TIMER_CHARGING_WITH_CLIMATISATION,
+    'preferred_charging_times': VWEudaChargeMode.PREFERRED_CHARGING_TIMES,
+    'only_own_current': VWEudaChargeMode.ONLY_OWN_CURRENT,
+    'home_storage_charging': VWEudaChargeMode.HOME_STORAGE_CHARGING,
+    'immediate_charging': VWEudaChargeMode.IMMEDIATE_CHARGING,
+    'immediate_discharging': VWEudaChargeMode.IMMEDIATE_DISCHARGING,
+}
+
+
+def _charge_mode(raw) -> "Optional[VWEudaChargeMode]":
+    """Normalise a dotted ``charge_mode_selection`` value to VWEudaChargeMode.
+
+    Returns None when there is nothing to map (absent/empty) and ``UNKNOWN`` when
+    a value is present but unrecognised, so a new value is surfaced rather than
+    silently dropped.
+    """
+    if raw is None:
+        return None
+    token = str(raw).strip().upper()
+    if not token:
+        return None
+    if token.startswith('CHARGE_MODE_SELECTION_'):
+        token = token[len('CHARGE_MODE_SELECTION_'):]
+    return _CHARGE_MODE_TOKENS.get(token, VWEudaChargeMode.UNKNOWN)
+
+
+def _charge_mode_flat(dataset) -> "Optional[VWEudaChargeMode]":
+    """Pick the active charge mode from the flat per-option booleans."""
+    for suffix, mode in _CHARGE_MODE_FLAT.items():
+        value = dataset.value_of(f'charge_mode_selection_options.{suffix}')
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            active = value
+        elif isinstance(value, (int, float)):
+            active = value != 0
+        else:
+            active = str(value).strip().lower() in ('true', '1', 'yes', 'on')
+        if active:
+            return mode
     return None
 
 
@@ -877,6 +977,24 @@ class Connector(BaseConnector):
         target_soc = dataset.value_of('settings.target_soc')
         if target_soc is not None:
             vehicle.charging.settings.target_level._set_value(value=target_soc, measured=captured_at)  # pylint: disable=protected-access
+
+        # Selected charge mode (charge_mode_selection). The dotted format carries a
+        # single value; the flat/continuous format splits it into one boolean per
+        # option, of which the active one is set. Neutral name `charge_mode`: the
+        # field is the *selected* mode (one value being `preferred_charging_times`),
+        # not necessarily a "preferred" one. Read-only, no commands here. The
+        # attribute is created lazily and tagged connector_custom (no core model).
+        charge_mode = _charge_mode(dataset.value_of('settings.charge_mode_selection'))
+        if charge_mode is None:
+            charge_mode = _charge_mode_flat(dataset)
+        if charge_mode is not None:
+            settings = vehicle.charging.settings
+            charge_mode_attr = getattr(settings, 'charge_mode', None)
+            if not isinstance(charge_mode_attr, EnumAttribute):
+                charge_mode_attr = EnumAttribute(name='charge_mode', parent=settings,
+                                                 value_type=VWEudaChargeMode, tags={'connector_custom'})
+                settings.charge_mode = charge_mode_attr
+            charge_mode_attr._set_value(charge_mode, measured=captured_at)  # pylint: disable=protected-access
 
         # --- Flat-format charging fields (eGolf / PHEV) ----------------------
         # Mirror the dotted battery_state_report.* / charging_state_report.* fields

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -739,8 +739,8 @@ class Connector(BaseConnector):
 
             drive = vehicle.get_electric_drive()
             if drive is None:
-                drive = ElectricDrive(drive_id='primary', drives=vehicle.drives,
-                                      initialization=vehicle.drives.get_initialization('primary'))
+                drive = ElectricDrive(drive_id='electric', drives=vehicle.drives,
+                                      initialization=vehicle.drives.get_initialization('electric'))
                 drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
                 vehicle.drives.add_drive(drive)
 
@@ -773,8 +773,8 @@ class Connector(BaseConnector):
         """Map EV-specific fields (SoC, charging, battery temps, range)."""
         drive = vehicle.get_electric_drive()
         if drive is None:
-            drive = ElectricDrive(drive_id='primary', drives=vehicle.drives,
-                                  initialization=vehicle.drives.get_initialization('primary'))
+            drive = ElectricDrive(drive_id='electric', drives=vehicle.drives,
+                                  initialization=vehicle.drives.get_initialization('electric'))
             drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
             vehicle.drives.add_drive(drive)
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -21,10 +21,10 @@ from datetime import datetime, timedelta, timezone
 
 from carconnectivity.errors import AuthenticationError, RetrievalError, TooManyRequestsError
 from carconnectivity.util import config_remove_credentials
-from carconnectivity.units import EnergyConsumption, Length, Power, Speed, Temperature
+from carconnectivity.units import EnergyConsumption, FuelConsumption, Length, Power, Speed, Temperature
 from carconnectivity.attributes import DurationAttribute, EnumAttribute
-from carconnectivity.vehicle import GenericVehicle
-from carconnectivity.drive import ElectricDrive, GenericDrive
+from carconnectivity.vehicle import GenericVehicle, ElectricVehicle, CombustionVehicle
+from carconnectivity.drive import CombustionDrive, ElectricDrive, GenericDrive
 from carconnectivity.battery import Battery
 from carconnectivity.charging import Charging
 from carconnectivity.charging_connector import ChargingConnector
@@ -47,7 +47,9 @@ from carconnectivity_connectors.vw_eu_data_act.dataset import (
     Dataset, decikelvin_to_celsius, parse_timestamp, resolve_charge_rate_unit, resolve_distance_unit,
 )
 from carconnectivity_connectors.vw_eu_data_act.brands import resolve_brand
-from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
+from carconnectivity_connectors.vw_eu_data_act.vehicle import (
+    VWEudaCombustionVehicle, VWEudaElectricVehicle, VWEudaHybridVehicle, VWEudaVehicle,
+)
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Tuple
@@ -182,6 +184,11 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'external_power_supply_state',
     'remaining_charging_time',
     'long_term_data_average_electr_engine_consumption',
+    # Combustion / PHEV (mapped in _map_combustion).
+    'fuel_level_current_level',
+    'tank_current_level',
+    'long_term_data_average_fuel_consumption',
+    'cruising_range_secondary_engine',
     # Door / window / light status (mapped in _map_status).
     'lock_state',
     'parking_lights',
@@ -617,19 +624,47 @@ class Connector(BaseConnector):
             return
         captured_at = dataset.captured_at
 
-        # Promote to an electric vehicle once we see EV-specific data. Some vehicles
-        # (e.g. eGolf) report the flat field names state_of_charge / cruising_range_primary_engine
-        # instead of the nested battery_state_report.* / charging_state_report.* paths.
-        is_ev = dataset.by_field('battery_state_report.soc') is not None \
-            or dataset.by_field('battery_state_report.charge_power') is not None \
-            or dataset.by_field('charging_state_report.current_charge_state') is not None \
-            or dataset.by_field('state_of_charge') is not None \
-            or dataset.by_field('cruising_range_primary_engine') is not None
-        if is_ev and not isinstance(vehicle, VWEudaElectricVehicle):
-            LOG.debug('Promoting %s to VWEudaElectricVehicle for %s', vehicle.__class__.__name__, vin)
-            vehicle = VWEudaElectricVehicle(garage=garage, origin=vehicle)
+        # Detect the drivetrain from which data the portal reports and promote the
+        # vehicle to the matching subclass. There is no single "powertrain" field
+        # and the field set varies by platform/format, so we detect by presence:
+        #   - electric: battery SoC / charge power / charge state / electric range
+        #   - fuel:     fuel level / petrol consumption
+        # A car reporting both is a plug-in hybrid (PHEV). Promotion only ever moves
+        # "up" (Hybrid is a subclass of both Electric and Combustion), so a partial
+        # dataset never demotes an already-richer vehicle.
+        has_electric = any(dataset.by_field(f) is not None for f in (
+            'battery_state_report.soc', 'battery_state_report.charge_power',
+            'charging_state_report.current_charge_state', 'state_of_charge',
+            'cruising_range_secondary_engine'))
+        has_fuel = any(dataset.by_field(f) is not None for f in (
+            'fuel_level_current_level', 'tank_current_level',
+            'long_term_data_average_fuel_consumption', 'short_term_data_average_fuel_consumption'))
+        # A pure EV in flat format reports only cruising_range_primary_engine (its
+        # electric range) with no fuel fields; treat that as electric.
+        if not has_electric and not has_fuel \
+                and dataset.by_field('cruising_range_primary_engine') is not None:
+            has_electric = True
+
+        # "already" tests the CarConnectivity base capabilities (HybridVehicle is
+        # both an ElectricVehicle and a CombustionVehicle), so a partial dataset
+        # never demotes a richer vehicle.
+        if has_electric and has_fuel:
+            desired, desired_type = VWEudaHybridVehicle, GenericVehicle.Type.HYBRID
+            already = isinstance(vehicle, ElectricVehicle) and isinstance(vehicle, CombustionVehicle)
+        elif has_electric:
+            desired, desired_type = VWEudaElectricVehicle, GenericVehicle.Type.ELECTRIC
+            already = isinstance(vehicle, ElectricVehicle)
+        elif has_fuel:
+            desired, desired_type = VWEudaCombustionVehicle, GenericVehicle.Type.GASOLINE
+            already = isinstance(vehicle, CombustionVehicle)
+        else:
+            desired, desired_type, already = None, None, True
+        if desired is not None and not already:
+            LOG.debug('Promoting %s to %s for %s', vehicle.__class__.__name__, desired.__name__, vin)
+            vehicle = desired(garage=garage, origin=vehicle)
             garage.replace_vehicle(vin, vehicle)
-            vehicle.type._set_value(GenericVehicle.Type.ELECTRIC)  # pylint: disable=protected-access
+            vehicle.type._set_value(desired_type)  # pylint: disable=protected-access
+        is_phev = has_electric and has_fuel
 
         # Odometer (mileage.value). The portal reports km or miles depending on
         # the vehicle; the unit comes from the companion mileage.unit enum, with
@@ -696,7 +731,7 @@ class Connector(BaseConnector):
         # Doors, windows and lights status (applies to all vehicles).
         self._map_status(vehicle, dataset, captured_at)
 
-        if isinstance(vehicle, VWEudaElectricVehicle):
+        if isinstance(vehicle, ElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)
 
             drive = vehicle.get_electric_drive()
@@ -713,9 +748,12 @@ class Connector(BaseConnector):
                 drive.level._set_value(value=soc, measured=captured_at)  # pylint: disable=protected-access
                 drive.level.precision = 1
 
-            rng = dataset.value_of('cruising_range_primary_engine')
-            if rng is not None:
-                drive.range._set_value(value=rng, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
+            # On a PHEV the electric range is the *secondary* engine; on a pure EV
+            # it is reported as the primary engine.
+            e_range = dataset.value_of('cruising_range_secondary_engine') if is_phev \
+                else dataset.value_of('cruising_range_primary_engine')
+            if e_range is not None:
+                drive.range._set_value(value=e_range, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
                 drive.range.precision = 1
 
             # Some flat-format datasets only provide a bare 'mileage' field.
@@ -723,6 +761,9 @@ class Connector(BaseConnector):
             if flat_mileage is not None and mileage is None:
                 vehicle.odometer._set_value(value=flat_mileage, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
                 vehicle.odometer.precision = 1
+
+        if isinstance(vehicle, CombustionVehicle):
+            self._map_combustion(vehicle, dataset, captured_at)
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
                       captured_at: "Optional[datetime]") -> None:
@@ -897,6 +938,36 @@ class Connector(BaseConnector):
                 vehicle.lights.lights['parking'] = light
             light.light_state._set_value(Lights.LightState(light_code), measured=captured_at)  # pylint: disable=protected-access
             vehicle.lights.enabled = True
+
+    def _map_combustion(self, vehicle: "VWEudaVehicle", dataset: Dataset,
+                        captured_at: "Optional[datetime]") -> None:
+        """Map combustion-engine fields (fuel level, petrol range and consumption)."""
+        drive = vehicle.get_combustion_drive()
+        if drive is None:
+            drive = CombustionDrive(drive_id='combustion', drives=vehicle.drives,
+                                    initialization=vehicle.drives.get_initialization('combustion'))
+            drive.type._set_value(GenericDrive.Type.GASOLINE)  # pylint: disable=protected-access
+            vehicle.drives.add_drive(drive)
+
+        # Fuel level (%): prefer the dedicated current level, fall back to tank level.
+        fuel = dataset.value_of('fuel_level_current_level')
+        if fuel is None:
+            fuel = dataset.value_of('tank_current_level')
+        if isinstance(fuel, (int, float)):
+            drive.level._set_value(value=fuel, measured=captured_at)  # pylint: disable=protected-access
+            drive.level.precision = 1
+
+        # Petrol (combustion) range = the primary engine on a PHEV.
+        fuel_range = dataset.value_of('cruising_range_primary_engine')
+        if fuel_range is not None:
+            drive.range._set_value(value=fuel_range, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
+            drive.range.precision = 1
+
+        # Average fuel consumption (long term): portal reports L/1000km, /10 -> L/100km.
+        consumption = dataset.value_of('long_term_data_average_fuel_consumption')
+        if isinstance(consumption, (int, float)):
+            drive.consumption._set_value(  # pylint: disable=protected-access
+                value=round(consumption / 10, 1), measured=captured_at, unit=FuelConsumption.L100KM)
 
     # -- scheduling --------------------------------------------------------
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -189,6 +189,7 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'tank_current_level',
     'long_term_data_average_fuel_consumption',
     'cruising_range_secondary_engine',
+    'cruising_range_combined',
     'scr_range',
     # Door / window / light status (mapped in _map_status).
     'window_heating_state_front',
@@ -772,6 +773,13 @@ class Connector(BaseConnector):
 
         if isinstance(vehicle, CombustionVehicle):
             self._map_combustion(vehicle, dataset, captured_at)
+
+        # Combined (total) range across all drives, when the portal reports it
+        # directly (the seatcupra connector instead sums the per-engine ranges).
+        combined = dataset.value_of('cruising_range_combined')
+        if combined is not None:
+            vehicle.drives.total_range._set_value(value=combined, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
+            vehicle.drives.total_range.precision = 1
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
                       captured_at: "Optional[datetime]", drive_id: str = 'primary') -> None:

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -189,7 +189,10 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'tank_current_level',
     'long_term_data_average_fuel_consumption',
     'cruising_range_secondary_engine',
+    'scr_range',
     # Door / window / light status (mapped in _map_status).
+    'window_heating_state_front',
+    'window_heating_state_rear',
     'lock_state',
     'parking_lights',
     'open_state_front_left_door', 'open_state_front_right_door',
@@ -939,6 +942,26 @@ class Connector(BaseConnector):
             light.light_state._set_value(Lights.LightState(light_code), measured=captured_at)  # pylint: disable=protected-access
             vehicle.lights.enabled = True
 
+        # Per-window heating (front / rear); the flat fields carry "on" / "off".
+        for window_id, field in (('front', 'window_heating_state_front'),
+                                  ('rear', 'window_heating_state_rear')):
+            wh = dataset.value_of(field)
+            if not isinstance(wh, str):
+                continue
+            try:
+                state = WindowHeatings.HeatingState(wh.strip().lower())
+            except ValueError:
+                state = WindowHeatings.HeatingState.UNKNOWN
+            heater = vehicle.window_heatings.windows.get(window_id)
+            if heater is None:
+                heater = WindowHeatings.WindowHeating(window_id=window_id,
+                                                      window_heatings=vehicle.window_heatings)
+                heater.enabled = True
+                vehicle.window_heatings.windows[window_id] = heater
+            heater.heating_state._set_value(state, measured=captured_at)  # pylint: disable=protected-access
+        if vehicle.window_heatings.windows:
+            vehicle.window_heatings.enabled = True
+
     def _map_combustion(self, vehicle: "VWEudaVehicle", dataset: Dataset,
                         captured_at: "Optional[datetime]") -> None:
         """Map combustion-engine fields (fuel level, petrol range and consumption)."""
@@ -968,6 +991,13 @@ class Connector(BaseConnector):
         if isinstance(consumption, (int, float)):
             drive.consumption._set_value(  # pylint: disable=protected-access
                 value=round(consumption / 10, 1), measured=captured_at, unit=FuelConsumption.L100KM)
+
+        # SCR / AdBlue range (diesel only; empty on petrol / PHEV).
+        adblue_range = dataset.value_of('scr_range')
+        if isinstance(adblue_range, (int, float)):
+            drive.adblue_range._set_value(  # pylint: disable=protected-access
+                value=adblue_range, measured=captured_at, unit=Length.KM)
+            drive.adblue_range.precision = 1
 
     # -- scheduling --------------------------------------------------------
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -205,6 +205,9 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'state_front_left_door_window_lifter', 'state_front_right_door_window_lifter',
     'state_rear_left_door_window_lifter', 'state_rear_right_door_window_lifter',
     'state_sunroof_motor_hood_1',
+    'position_front_left_door_window_lifter', 'position_front_right_door_window_lifter',
+    'position_rear_left_door_window_lifter', 'position_rear_right_door_window_lifter',
+    'position_sunroof_motor_hood_1',
 }
 
 # Portal door id -> (open_state field, locked_state field). Note the double
@@ -218,13 +221,17 @@ _DOOR_FIELDS: "Dict[str, Tuple[str, str]]" = {
     'tailgate': ('open_state_tailgate', 'locked_state_tailgate'),
 }
 
-# Portal window id -> open/closed state field.
-_WINDOW_FIELDS: "Dict[str, str]" = {
-    'front_left': 'state_front_left_door_window_lifter',
-    'front_right': 'state_front_right_door_window_lifter',
-    'rear_left': 'state_rear_left_door_window_lifter',
-    'rear_right': 'state_rear_right_door_window_lifter',
-    'sunroof': 'state_sunroof_motor_hood_1',
+# Portal window id -> (opening-percentage field, open/closed state field).
+# The portal exposes both: position_* is the opening percentage (unit '%', 0 =
+# closed) and state_* is the coarse open/closed code. We prefer the percentage
+# because it also lets us tell a partly-open (ajar) window from a fully open one;
+# state_* is the fallback when the percentage is missing.
+_WINDOW_FIELDS: "Dict[str, Tuple[str, str]]" = {
+    'front_left': ('position_front_left_door_window_lifter', 'state_front_left_door_window_lifter'),
+    'front_right': ('position_front_right_door_window_lifter', 'state_front_right_door_window_lifter'),
+    'rear_left': ('position_rear_left_door_window_lifter', 'state_rear_left_door_window_lifter'),
+    'rear_right': ('position_rear_right_door_window_lifter', 'state_rear_right_door_window_lifter'),
+    'sunroof': ('position_sunroof_motor_hood_1', 'state_sunroof_motor_hood_1'),
 }
 
 
@@ -235,6 +242,27 @@ def _open_code(value) -> "Optional[str]":
     if value == 3:
         return 'closed'
     return None
+
+
+def _window_open_code(position, state) -> "Optional[str]":
+    """Decode a window opening from the portal.
+
+    The percentage (position_*, 0..100) is preferred: 0 = closed, 100 = open,
+    anything in between = ajar (CarConnectivity has no numeric window position,
+    only an open/closed/ajar enum). When the percentage is absent or out of range
+    fall back to the coarse state_* open/closed code.
+    """
+    try:
+        pct = float(position)
+    except (TypeError, ValueError):
+        pct = None
+    if pct is not None and 0 <= pct <= 100:
+        if pct <= 0:
+            return 'closed'
+        if pct >= 100:
+            return 'open'
+        return 'ajar'
+    return _open_code(state)
 
 
 def _lock_code(value) -> "Optional[str]":
@@ -930,9 +958,10 @@ class Connector(BaseConnector):
         if vehicle.doors.doors:
             vehicle.doors.enabled = True
 
-        # Per-window open state.
-        for window_id, state_f in _WINDOW_FIELDS.items():
-            open_code = _open_code(dataset.value_of(state_f))
+        # Per-window open state, preferring the opening percentage (which also
+        # surfaces an ajar window) over the coarse open/closed code.
+        for window_id, (position_f, state_f) in _WINDOW_FIELDS.items():
+            open_code = _window_open_code(dataset.value_of(position_f), dataset.value_of(state_f))
             if open_code is None:
                 continue
             window = vehicle.windows.windows.get(window_id)

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -24,7 +24,7 @@ from carconnectivity.util import config_remove_credentials
 from carconnectivity.units import EnergyConsumption, FuelConsumption, Length, Power, Speed, Temperature
 from carconnectivity.attributes import DurationAttribute, EnumAttribute
 from carconnectivity.vehicle import GenericVehicle, ElectricVehicle, CombustionVehicle
-from carconnectivity.drive import CombustionDrive, ElectricDrive, GenericDrive
+from carconnectivity.drive import CombustionDrive, DieselDrive, ElectricDrive, GenericDrive
 from carconnectivity.battery import Battery
 from carconnectivity.charging import Charging
 from carconnectivity.charging_connector import ChargingConnector
@@ -1007,13 +1007,25 @@ class Connector(BaseConnector):
     def _map_combustion(self, vehicle: "VWEudaVehicle", dataset: Dataset,
                         captured_at: "Optional[datetime]") -> None:
         """Map combustion-engine fields (fuel level, petrol range and consumption)."""
+        # The portal has no fuel-type field, so infer a diesel from a *numeric* SCR
+        # (AdBlue) range: petrol/PHEV cars also carry the scr_range field but report
+        # it as an empty string. A diesel needs a DieselDrive because adblue_range
+        # only exists there (a plain CombustionDrive would raise AttributeError).
+        adblue_range = dataset.value_of('scr_range')
+        is_diesel = isinstance(adblue_range, (int, float))
+
         # The combustion engine is the portal's primary engine (matching the
         # seatcupra convention where the primary slot is the fuel engine on a PHEV).
         drive = vehicle.get_combustion_drive()
         if drive is None:
-            drive = CombustionDrive(drive_id='primary', drives=vehicle.drives,
+            if is_diesel:
+                drive = DieselDrive(drive_id='primary', drives=vehicle.drives,
                                     initialization=vehicle.drives.get_initialization('primary'))
-            drive.type._set_value(GenericDrive.Type.GASOLINE)  # pylint: disable=protected-access
+                drive.type._set_value(GenericDrive.Type.DIESEL)  # pylint: disable=protected-access
+            else:
+                drive = CombustionDrive(drive_id='primary', drives=vehicle.drives,
+                                        initialization=vehicle.drives.get_initialization('primary'))
+                drive.type._set_value(GenericDrive.Type.GASOLINE)  # pylint: disable=protected-access
             vehicle.drives.add_drive(drive)
 
         # Fuel level (%): prefer the dedicated current level, fall back to tank level.
@@ -1036,9 +1048,9 @@ class Connector(BaseConnector):
             drive.consumption._set_value(  # pylint: disable=protected-access
                 value=round(consumption / 10, 1), measured=captured_at, unit=FuelConsumption.L100KM)
 
-        # SCR / AdBlue range (diesel only; empty on petrol / PHEV).
-        adblue_range = dataset.value_of('scr_range')
-        if isinstance(adblue_range, (int, float)):
+        # SCR / AdBlue range (diesel only; empty on petrol / PHEV). adblue_range
+        # exists only on DieselDrive, so guard exactly like the official connectors.
+        if is_diesel and isinstance(drive, DieselDrive):
             drive.adblue_range._set_value(  # pylint: disable=protected-access
                 value=adblue_range, measured=captured_at, unit=Length.KM)
             drive.adblue_range.precision = 1

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -585,15 +585,17 @@ class Connector(BaseConnector):
         # value is the amount still remaining, zero is due, a positive value is
         # overdue. Expose the time interval as a concrete due date (which conveys
         # overdue naturally as a past date) and the distance as remaining km.
-        if captured_at is not None:
-            insp_days = dataset.value_of('maintenance_interval__time_until_inspection')
-            if insp_days is not None:
-                vehicle.maintenance.inspection_due_at._set_value(  # pylint: disable=protected-access
-                    value=captured_at + timedelta(days=-insp_days), measured=captured_at)
-            oil_days = dataset.value_of('maintenance_interval__time_until_oil_change')
-            if oil_days is not None:
-                vehicle.maintenance.oil_service_due_at._set_value(  # pylint: disable=protected-access
-                    value=captured_at + timedelta(days=-oil_days), measured=captured_at)
+        # The bootstrap-merged dataset can lack a capture time, so anchor the due
+        # date on "now" when captured_at is absent.
+        date_anchor = captured_at or datetime.now(tz=timezone.utc)
+        insp_days = dataset.value_of('maintenance_interval__time_until_inspection')
+        if insp_days is not None:
+            vehicle.maintenance.inspection_due_at._set_value(  # pylint: disable=protected-access
+                value=date_anchor + timedelta(days=-insp_days), measured=captured_at)
+        oil_days = dataset.value_of('maintenance_interval__time_until_oil_change')
+        if oil_days is not None:
+            vehicle.maintenance.oil_service_due_at._set_value(  # pylint: disable=protected-access
+                value=date_anchor + timedelta(days=-oil_days), measured=captured_at)
         insp_dist = dataset.value_of('maintenance_interval_distance_until_inspection')
         if insp_dist is not None:
             vehicle.maintenance.inspection_due_after._set_value(  # pylint: disable=protected-access
@@ -611,15 +613,14 @@ class Connector(BaseConnector):
         # Remaining climatisation time -> estimated completion date. The dotted
         # format delivers "<seconds>s"; the flat PHEV format delivers integer
         # minutes (remaining_climatisation_time).
-        if captured_at is not None:
-            clim_seconds = dataset.value_of('remaining_climate_time')
-            clim_minutes = dataset.value_of('remaining_climatisation_time')
-            if clim_seconds is not None:
-                vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
-                    value=captured_at + timedelta(seconds=clim_seconds), measured=captured_at)
-            elif clim_minutes is not None:
-                vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
-                    value=captured_at + timedelta(minutes=clim_minutes), measured=captured_at)
+        clim_seconds = dataset.value_of('remaining_climate_time')
+        clim_minutes = dataset.value_of('remaining_climatisation_time')
+        if clim_seconds is not None:
+            vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                value=date_anchor + timedelta(seconds=clim_seconds), measured=captured_at)
+        elif clim_minutes is not None:
+            vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                value=date_anchor + timedelta(minutes=clim_minutes), measured=captured_at)
 
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -41,8 +41,9 @@ from carconnectivity_connectors.vw_eu_data_act.client import (
     ApiError, AuthError, EudaApiClient,
 )
 from carconnectivity_connectors.vw_eu_data_act.dataset import (
-    Dataset, parse_timestamp, resolve_charge_rate_unit, resolve_distance_unit,
+    Dataset, decikelvin_to_celsius, parse_timestamp, resolve_charge_rate_unit, resolve_distance_unit,
 )
+from carconnectivity_connectors.vw_eu_data_act.brands import resolve_brand
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
 
 if TYPE_CHECKING:
@@ -163,6 +164,14 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'mileage',
     'state_of_charge',
     'cruising_range_primary_engine',
+    # Maintenance / climate / ambient (mapped in _map_dataset).
+    'maintenance_interval__time_until_inspection',
+    'maintenance_interval__time_until_oil_change',
+    'maintenance_interval_distance_until_inspection',
+    'maintenance_interval_distance_until_oil_change',
+    'outside_temperature',
+    'remaining_climate_time',
+    'remaining_climatisation_time',
 }
 
 
@@ -350,6 +359,10 @@ class Connector(BaseConnector):
             if vehicle is None:
                 vehicle = VWEudaVehicle(vin=vin, garage=garage, managing_connector=self,
                                         initialization=garage.get_initialization(vin))
+                # Label the manufacturer from the configured brand (Volkswagen,
+                # Audi, Skoda, SEAT, Cupra, Bentley, ...) instead of always "Volkswagen".
+                vehicle.manufacturer._set_value(  # pylint: disable=protected-access
+                    resolve_brand(self.active_config['brand']).manufacturer)
                 garage.add_vehicle(vin, vehicle)
             if veh.get('nickname'):
                 vehicle.name._set_value(veh['nickname'])  # pylint: disable=protected-access
@@ -567,6 +580,46 @@ class Connector(BaseConnector):
         if isinstance(wh, str):
             vehicle.window_heatings.heating_state._set_value(  # pylint: disable=protected-access
                 WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN), measured=captured_at)
+
+        # Maintenance intervals. The portal encodes a signed countdown: a negative
+        # value is the amount still remaining, zero is due, a positive value is
+        # overdue. Expose the time interval as a concrete due date (which conveys
+        # overdue naturally as a past date) and the distance as remaining km.
+        if captured_at is not None:
+            insp_days = dataset.value_of('maintenance_interval__time_until_inspection')
+            if insp_days is not None:
+                vehicle.maintenance.inspection_due_at._set_value(  # pylint: disable=protected-access
+                    value=captured_at + timedelta(days=-insp_days), measured=captured_at)
+            oil_days = dataset.value_of('maintenance_interval__time_until_oil_change')
+            if oil_days is not None:
+                vehicle.maintenance.oil_service_due_at._set_value(  # pylint: disable=protected-access
+                    value=captured_at + timedelta(days=-oil_days), measured=captured_at)
+        insp_dist = dataset.value_of('maintenance_interval_distance_until_inspection')
+        if insp_dist is not None:
+            vehicle.maintenance.inspection_due_after._set_value(  # pylint: disable=protected-access
+                value=abs(insp_dist), measured=captured_at, unit=Length.KM)
+        oil_dist = dataset.value_of('maintenance_interval_distance_until_oil_change')
+        if oil_dist is not None:
+            vehicle.maintenance.oil_service_due_after._set_value(  # pylint: disable=protected-access
+                value=abs(oil_dist), measured=captured_at, unit=Length.KM)
+
+        # Outside (ambient) temperature, reported in deci-Kelvin.
+        outside = decikelvin_to_celsius(dataset.value_of('outside_temperature'))
+        if outside is not None:
+            vehicle.outside_temperature._set_value(value=outside, measured=captured_at, unit=Temperature.C)  # pylint: disable=protected-access
+
+        # Remaining climatisation time -> estimated completion date. The dotted
+        # format delivers "<seconds>s"; the flat PHEV format delivers integer
+        # minutes (remaining_climatisation_time).
+        if captured_at is not None:
+            clim_seconds = dataset.value_of('remaining_climate_time')
+            clim_minutes = dataset.value_of('remaining_climatisation_time')
+            if clim_seconds is not None:
+                vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                    value=captured_at + timedelta(seconds=clim_seconds), measured=captured_at)
+            elif clim_minutes is not None:
+                vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                    value=captured_at + timedelta(minutes=clim_minutes), measured=captured_at)
 
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -193,6 +193,9 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'plug_state',
     'external_power_supply_state',
     'remaining_charging_time',
+    'charging_power',
+    'actual_charge_rate',
+    'charge_rate_unit',
     'long_term_data_average_electr_engine_consumption',
     # Combustion / PHEV (mapped in _map_combustion).
     'fuel_level_current_level',
@@ -1015,6 +1018,22 @@ class Connector(BaseConnector):
             except ValueError:
                 type_enum = Charging.ChargingType.UNKNOWN
             vehicle.charging.type._set_value(type_enum, measured=captured_at)  # pylint: disable=protected-access
+
+        # Flat-format charge power: a deci-kW integer (e.g. 99 -> 9.9 kW on
+        # Passat/Tayron/Golf PHEV). Mapped only when the dotted
+        # battery_state_report.charge_power (already scaled kW) is absent, so the
+        # dotted behaviour is untouched.
+        flat_power = dataset.value_of('charging_power')
+        if isinstance(flat_power, (int, float)) and power is None:
+            vehicle.charging.power._set_value(value=flat_power / 10, measured=captured_at, unit=Power.KW)  # pylint: disable=protected-access
+
+        # Flat-format charge rate: same deci scaling; the unit comes from the flat
+        # charge_rate_unit companion (km/mi, per-h/min), normalised to a per-hour
+        # speed. Mapped only when the dotted battery_state_report.charge_rate is absent.
+        flat_rate = dataset.value_of('actual_charge_rate')
+        if isinstance(flat_rate, (int, float)) and charge_rate is None:
+            rate_value, rate_unit = _charge_rate_per_hour(flat_rate / 10, dataset.value_of('charge_rate_unit'))
+            vehicle.charging.rate._set_value(value=rate_value, measured=captured_at, unit=rate_unit)  # pylint: disable=protected-access
 
         plug = dataset.value_of('plug_state')
         if isinstance(plug, str):

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -29,6 +29,8 @@ from carconnectivity.battery import Battery
 from carconnectivity.charging import Charging
 from carconnectivity.charging_connector import ChargingConnector
 from carconnectivity.doors import Doors
+from carconnectivity.windows import Windows
+from carconnectivity.lights import Lights
 from carconnectivity.window_heating import WindowHeatings
 from carconnectivity.enums import ConnectionState
 
@@ -180,7 +182,68 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'external_power_supply_state',
     'remaining_charging_time',
     'long_term_data_average_electr_engine_consumption',
+    # Door / window / light status (mapped in _map_status).
+    'lock_state',
+    'parking_lights',
+    'open_state_front_left_door', 'open_state_front_right_door',
+    'open_state_rear_left_door', 'open_state_rear_right_door',
+    'open_state_front_engine_bonnet', 'open_state_tailgate',
+    'locked_state_front_left_door', 'locked_state_front_right_door',
+    'locked_state__rear_left_door', 'locked_state_rear_right_door',
+    'locked_state_front_engine_bonnet', 'locked_state_tailgate',
+    'state_front_left_door_window_lifter', 'state_front_right_door_window_lifter',
+    'state_rear_left_door_window_lifter', 'state_rear_right_door_window_lifter',
+    'state_sunroof_motor_hood_1',
 }
+
+# Portal door id -> (open_state field, locked_state field). Note the double
+# underscore in the rear-left lock field (portal quirk).
+_DOOR_FIELDS: "Dict[str, Tuple[str, str]]" = {
+    'front_left': ('open_state_front_left_door', 'locked_state_front_left_door'),
+    'front_right': ('open_state_front_right_door', 'locked_state_front_right_door'),
+    'rear_left': ('open_state_rear_left_door', 'locked_state__rear_left_door'),
+    'rear_right': ('open_state_rear_right_door', 'locked_state_rear_right_door'),
+    'bonnet': ('open_state_front_engine_bonnet', 'locked_state_front_engine_bonnet'),
+    'tailgate': ('open_state_tailgate', 'locked_state_tailgate'),
+}
+
+# Portal window id -> open/closed state field.
+_WINDOW_FIELDS: "Dict[str, str]" = {
+    'front_left': 'state_front_left_door_window_lifter',
+    'front_right': 'state_front_right_door_window_lifter',
+    'rear_left': 'state_rear_left_door_window_lifter',
+    'rear_right': 'state_rear_right_door_window_lifter',
+    'sunroof': 'state_sunroof_motor_hood_1',
+}
+
+
+def _open_code(value) -> "Optional[str]":
+    """Decode the portal 'open' encoding: 2 = open, 3 = closed, 0/1 = invalid."""
+    if value == 2:
+        return 'open'
+    if value == 3:
+        return 'closed'
+    return None
+
+
+def _lock_code(value) -> "Optional[str]":
+    """Decode the portal 'open' encoding for locks: 2 = locked, 3 = unlocked."""
+    if value == 2:
+        return 'locked'
+    if value == 3:
+        return 'unlocked'
+    return None
+
+
+def _light_code(value) -> "Optional[str]":
+    """Decode the portal 'lights' encoding: 2 = off, 3/4/5 = on, 0/1 = invalid."""
+    if value in (0, 1):
+        return None
+    if value == 2:
+        return 'off'
+    if value in (3, 4, 5):
+        return 'on'
+    return None
 
 
 class Connector(BaseConnector):
@@ -630,6 +693,9 @@ class Connector(BaseConnector):
             vehicle.climatization.estimated_date_reached._set_value(  # pylint: disable=protected-access
                 value=date_anchor + timedelta(minutes=clim_minutes), measured=captured_at)
 
+        # Doors, windows and lights status (applies to all vehicles).
+        self._map_status(vehicle, dataset, captured_at)
+
         if isinstance(vehicle, VWEudaElectricVehicle):
             self._map_electric(vehicle, dataset, captured_at)
 
@@ -776,6 +842,61 @@ class Connector(BaseConnector):
         if isinstance(consumption, (int, float)):
             drive.consumption._set_value(  # pylint: disable=protected-access
                 value=round(consumption / 10, 1), measured=captured_at, unit=EnergyConsumption.KWH100KM)
+
+    def _map_status(self, vehicle: "VWEudaVehicle", dataset: Dataset,
+                    captured_at: "Optional[datetime]") -> None:
+        """Map per-door / per-window open+lock state and lights onto CarConnectivity."""
+        # Overall central lock (flat string field).
+        lock = dataset.value_of('lock_state')
+        if isinstance(lock, str):
+            text = lock.strip().lower()
+            if text == 'locked':
+                vehicle.doors.lock_state._set_value(Doors.LockState.LOCKED, measured=captured_at)  # pylint: disable=protected-access
+            elif text == 'unlocked':
+                vehicle.doors.lock_state._set_value(Doors.LockState.UNLOCKED, measured=captured_at)  # pylint: disable=protected-access
+
+        # Per-door open + lock state.
+        for door_id, (open_f, lock_f) in _DOOR_FIELDS.items():
+            open_code = _open_code(dataset.value_of(open_f))
+            lock_code = _lock_code(dataset.value_of(lock_f))
+            if open_code is None and lock_code is None:
+                continue
+            door = vehicle.doors.doors.get(door_id)
+            if door is None:
+                door = Doors.Door(door_id=door_id, doors=vehicle.doors)
+                door.enabled = True
+                vehicle.doors.doors[door_id] = door
+            if open_code is not None:
+                door.open_state._set_value(Doors.OpenState(open_code), measured=captured_at)  # pylint: disable=protected-access
+            if lock_code is not None:
+                door.lock_state._set_value(Doors.LockState(lock_code), measured=captured_at)  # pylint: disable=protected-access
+        if vehicle.doors.doors:
+            vehicle.doors.enabled = True
+
+        # Per-window open state.
+        for window_id, state_f in _WINDOW_FIELDS.items():
+            open_code = _open_code(dataset.value_of(state_f))
+            if open_code is None:
+                continue
+            window = vehicle.windows.windows.get(window_id)
+            if window is None:
+                window = Windows.Window(window_id=window_id, windows=vehicle.windows)
+                window.enabled = True
+                vehicle.windows.windows[window_id] = window
+            window.open_state._set_value(Windows.OpenState(open_code), measured=captured_at)  # pylint: disable=protected-access
+        if vehicle.windows.windows:
+            vehicle.windows.enabled = True
+
+        # Parking lights.
+        light_code = _light_code(dataset.value_of('parking_lights'))
+        if light_code is not None:
+            light = vehicle.lights.lights.get('parking')
+            if light is None:
+                light = Lights.Light(light_id='parking', lights=vehicle.lights)
+                light.enabled = True
+                vehicle.lights.lights['parking'] = light
+            light.light_state._set_value(Lights.LightState(light_code), measured=captured_at)  # pylint: disable=protected-access
+            vehicle.lights.enabled = True
 
     # -- scheduling --------------------------------------------------------
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -21,12 +21,13 @@ from datetime import datetime, timedelta, timezone
 
 from carconnectivity.errors import AuthenticationError, RetrievalError, TooManyRequestsError
 from carconnectivity.util import config_remove_credentials
-from carconnectivity.units import Length, Power, Speed, Temperature
+from carconnectivity.units import EnergyConsumption, Length, Power, Speed, Temperature
 from carconnectivity.attributes import DurationAttribute, EnumAttribute
 from carconnectivity.vehicle import GenericVehicle
 from carconnectivity.drive import ElectricDrive, GenericDrive
 from carconnectivity.battery import Battery
 from carconnectivity.charging import Charging
+from carconnectivity.charging_connector import ChargingConnector
 from carconnectivity.doors import Doors
 from carconnectivity.window_heating import WindowHeatings
 from carconnectivity.enums import ConnectionState
@@ -172,6 +173,13 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'outside_temperature',
     'remaining_climate_time',
     'remaining_climatisation_time',
+    # Flat-format charging + consumption (mapped in _map_electric).
+    'charging_state',
+    'charging_mode',
+    'plug_state',
+    'external_power_supply_state',
+    'remaining_charging_time',
+    'long_term_data_average_electr_engine_consumption',
 }
 
 
@@ -718,6 +726,56 @@ class Connector(BaseConnector):
         target_soc = dataset.value_of('settings.target_soc')
         if target_soc is not None:
             vehicle.charging.settings.target_level._set_value(value=target_soc, measured=captured_at)  # pylint: disable=protected-access
+
+        # --- Flat-format charging fields (eGolf / PHEV) ----------------------
+        # Mirror the dotted battery_state_report.* / charging_state_report.* fields
+        # above but use simple lower-case string enums; map them when the dotted
+        # variants are absent. Their values match the CarConnectivity enum values.
+        flat_state = dataset.value_of('charging_state')
+        if isinstance(flat_state, str) and charge_state is None:
+            try:
+                state_enum = Charging.ChargingState(flat_state.strip().lower())
+            except ValueError:
+                state_enum = Charging.ChargingState.UNKNOWN
+            vehicle.charging.state._set_value(state_enum, measured=captured_at)  # pylint: disable=protected-access
+
+        flat_mode = dataset.value_of('charging_mode')
+        if isinstance(flat_mode, str) and charge_type is None:
+            try:
+                type_enum = Charging.ChargingType(flat_mode.strip().lower())
+            except ValueError:
+                type_enum = Charging.ChargingType.UNKNOWN
+            vehicle.charging.type._set_value(type_enum, measured=captured_at)  # pylint: disable=protected-access
+
+        plug = dataset.value_of('plug_state')
+        if isinstance(plug, str):
+            try:
+                vehicle.charging.connector.connection_state._set_value(  # pylint: disable=protected-access
+                    ChargingConnector.ChargingConnectorConnectionState(plug.strip().lower()), measured=captured_at)
+            except ValueError:
+                pass
+
+        ext_power = dataset.value_of('external_power_supply_state')
+        if isinstance(ext_power, str):
+            try:
+                vehicle.charging.connector.external_power._set_value(  # pylint: disable=protected-access
+                    ChargingConnector.ExternalPower(ext_power.strip().lower()), measured=captured_at)
+            except ValueError:
+                pass
+
+        # Flat remaining charging time is in MINUTES; 65535 is the "no value" sentinel.
+        flat_remaining = dataset.value_of('remaining_charging_time')
+        if isinstance(flat_remaining, (int, float)) and 0 <= flat_remaining < 65535 and remaining is None:
+            anchor = captured_at or datetime.now(tz=timezone.utc)
+            vehicle.charging.estimated_date_reached._set_value(  # pylint: disable=protected-access
+                value=anchor + timedelta(minutes=flat_remaining), measured=captured_at)
+
+        # Average electric consumption (long term): portal reports kWh/1000km,
+        # divide by 10 for kWh/100km.
+        consumption = dataset.value_of('long_term_data_average_electr_engine_consumption')
+        if isinstance(consumption, (int, float)):
+            drive.consumption._set_value(  # pylint: disable=protected-access
+                value=round(consumption / 10, 1), measured=captured_at, unit=EnergyConsumption.KWH100KM)
 
     # -- scheduling --------------------------------------------------------
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -734,13 +734,18 @@ class Connector(BaseConnector):
         # Doors, windows and lights status (applies to all vehicles).
         self._map_status(vehicle, dataset, captured_at)
 
+        # Drive slots follow the portal's primary/secondary engines (same convention
+        # as the official seatcupra connector): on a PHEV the primary engine is the
+        # combustion one and the secondary is electric; a pure EV has only the
+        # primary (electric) slot.
+        electric_drive_id = 'secondary' if is_phev else 'primary'
         if isinstance(vehicle, ElectricVehicle):
-            self._map_electric(vehicle, dataset, captured_at)
+            self._map_electric(vehicle, dataset, captured_at, electric_drive_id)
 
             drive = vehicle.get_electric_drive()
             if drive is None:
-                drive = ElectricDrive(drive_id='electric', drives=vehicle.drives,
-                                      initialization=vehicle.drives.get_initialization('electric'))
+                drive = ElectricDrive(drive_id=electric_drive_id, drives=vehicle.drives,
+                                      initialization=vehicle.drives.get_initialization(electric_drive_id))
                 drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
                 vehicle.drives.add_drive(drive)
 
@@ -769,12 +774,12 @@ class Connector(BaseConnector):
             self._map_combustion(vehicle, dataset, captured_at)
 
     def _map_electric(self, vehicle: VWEudaElectricVehicle, dataset: Dataset,
-                      captured_at: "Optional[datetime]") -> None:
+                      captured_at: "Optional[datetime]", drive_id: str = 'primary') -> None:
         """Map EV-specific fields (SoC, charging, battery temps, range)."""
         drive = vehicle.get_electric_drive()
         if drive is None:
-            drive = ElectricDrive(drive_id='electric', drives=vehicle.drives,
-                                  initialization=vehicle.drives.get_initialization('electric'))
+            drive = ElectricDrive(drive_id=drive_id, drives=vehicle.drives,
+                                  initialization=vehicle.drives.get_initialization(drive_id))
             drive.type._set_value(GenericDrive.Type.ELECTRIC)  # pylint: disable=protected-access
             vehicle.drives.add_drive(drive)
 
@@ -965,10 +970,12 @@ class Connector(BaseConnector):
     def _map_combustion(self, vehicle: "VWEudaVehicle", dataset: Dataset,
                         captured_at: "Optional[datetime]") -> None:
         """Map combustion-engine fields (fuel level, petrol range and consumption)."""
+        # The combustion engine is the portal's primary engine (matching the
+        # seatcupra convention where the primary slot is the fuel engine on a PHEV).
         drive = vehicle.get_combustion_drive()
         if drive is None:
-            drive = CombustionDrive(drive_id='combustion', drives=vehicle.drives,
-                                    initialization=vehicle.drives.get_initialization('combustion'))
+            drive = CombustionDrive(drive_id='primary', drives=vehicle.drives,
+                                    initialization=vehicle.drives.get_initialization('primary'))
             drive.type._set_value(GenericDrive.Type.GASOLINE)  # pylint: disable=protected-access
             vehicle.drives.add_drive(drive)
 

--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -120,6 +120,20 @@ def resolve_charge_rate_unit(enum_value, default=None):
     return default
 
 
+def decikelvin_to_celsius(value) -> Optional[float]:
+    """Convert a deci-Kelvin reading (e.g. 3061) to Celsius (33.0).
+
+    The portal reports outside_temperature in deci-Kelvin: degC = dK / 10 - 273.15.
+    Returns ``None`` for missing or non-numeric input.
+    """
+    if value is None:
+        return None
+    try:
+        return round(float(value) / 10 - 273.15, 1)
+    except (TypeError, ValueError):
+        return None
+
+
 # Ordered enum members (protobuf index order) for the curated enum fields this
 # connector maps, lifted from the VW EU Data Act data dictionary. The full
 # 1000-field dictionary is intentionally not shipped (see module docstring);

--- a/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
@@ -18,10 +18,13 @@ class VWEudaVehicle(GenericVehicle):
                  managing_connector: Optional[BaseConnector] = None,
                  origin: Optional[VWEudaVehicle] = None, initialization: Optional[Dict] = None) -> None:
         if origin is not None:
+            # Promotion path (e.g. to the electric subclass): keep the manufacturer
+            # already resolved from the brand on the origin vehicle; do not clobber it.
             super().__init__(garage=garage, origin=origin, initialization=initialization)
         else:
             super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
-        self.manufacturer._set_value(value='Volkswagen')  # pylint: disable=protected-access
+            # Default label; the connector overrides it from the configured brand.
+            self.manufacturer._set_value(value='Volkswagen')  # pylint: disable=protected-access
 
 
 class VWEudaElectricVehicle(ElectricVehicle, VWEudaVehicle):

--- a/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from carconnectivity.vehicle import GenericVehicle, ElectricVehicle
+from carconnectivity.vehicle import GenericVehicle, ElectricVehicle, CombustionVehicle, HybridVehicle
 
 if TYPE_CHECKING:
     from typing import Optional, Dict
@@ -29,6 +29,30 @@ class VWEudaVehicle(GenericVehicle):
 
 class VWEudaElectricVehicle(ElectricVehicle, VWEudaVehicle):
     """A Volkswagen electric vehicle sourced from the EU Data Act portal."""
+
+    def __init__(self, vin: Optional[str] = None, garage: Optional[Garage] = None,
+                 managing_connector: Optional[BaseConnector] = None,
+                 origin: Optional[VWEudaVehicle] = None, initialization: Optional[Dict] = None) -> None:
+        if origin is not None:
+            super().__init__(garage=garage, origin=origin, initialization=initialization)
+        else:
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
+
+
+class VWEudaCombustionVehicle(CombustionVehicle, VWEudaVehicle):
+    """A Volkswagen combustion vehicle sourced from the EU Data Act portal."""
+
+    def __init__(self, vin: Optional[str] = None, garage: Optional[Garage] = None,
+                 managing_connector: Optional[BaseConnector] = None,
+                 origin: Optional[VWEudaVehicle] = None, initialization: Optional[Dict] = None) -> None:
+        if origin is not None:
+            super().__init__(garage=garage, origin=origin, initialization=initialization)
+        else:
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
+
+
+class VWEudaHybridVehicle(HybridVehicle, VWEudaVehicle):
+    """A Volkswagen plug-in hybrid (PHEV) sourced from the EU Data Act portal."""
 
     def __init__(self, vin: Optional[str] = None, garage: Optional[Garage] = None,
                  managing_connector: Optional[BaseConnector] = None,

--- a/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/vehicle.py
@@ -51,7 +51,7 @@ class VWEudaCombustionVehicle(CombustionVehicle, VWEudaVehicle):
             super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
 
 
-class VWEudaHybridVehicle(HybridVehicle, VWEudaVehicle):
+class VWEudaHybridVehicle(HybridVehicle, VWEudaElectricVehicle, VWEudaCombustionVehicle):
     """A Volkswagen plug-in hybrid (PHEV) sourced from the EU Data Act portal."""
 
     def __init__(self, vin: Optional[str] = None, garage: Optional[Garage] = None,

--- a/tests/phev_sample_dataset.json
+++ b/tests/phev_sample_dataset.json
@@ -1,0 +1,541 @@
+{
+  "vin": "VWTESTVINPHEV0001",
+  "user_id": "test-user",
+  "Data": [
+    {
+      "key": "ac86e00b-7fa1-3a59-b481-aa7cfc49b0d9",
+      "dataFieldName": "maintenance_interval_distance_until_inspection",
+      "value": "-23500"
+    },
+    {
+      "key": "db6919e8-430a-35dc-a930-14d289be6985",
+      "dataFieldName": "locked_state_front_left_door",
+      "value": "3"
+    },
+    {
+      "key": "6e36232f-4c55-3688-9948-a3a6ae056db1",
+      "dataFieldName": "locked_state_rear_right_door",
+      "value": "3"
+    },
+    {
+      "key": "33d2c35b-8aac-3509-bb88-807682055b1b",
+      "dataFieldName": "tyre_pressure_actual_rear_left",
+      "value": "1"
+    },
+    {
+      "key": "5f913493-351d-3aa8-a1c5-20506d9d7f9a",
+      "dataFieldName": "tyre_pressure_actual_rear_right",
+      "value": "1"
+    },
+    {
+      "key": "bc5bacac-cea7-347e-9c1e-831026a3d996",
+      "dataFieldName": "short_term_data_average_aux_consumer_consumption",
+      "value": "0"
+    },
+    {
+      "key": "ecd266dd-f536-39c2-a575-352216b87f39",
+      "dataFieldName": "short_term_data_start_mileage",
+      "value": "40201"
+    },
+    {
+      "key": "a56a4e27-7d8d-3434-a746-4736c3b5a496",
+      "dataFieldName": "external_power_supply_state",
+      "value": "unavailable"
+    },
+    {
+      "key": "a86e735b-5f04-336a-8dc7-8fb189d02cd2",
+      "dataFieldName": "tyre_pressure_differential_front_right",
+      "value": "1"
+    },
+    {
+      "key": "7e35b2a4-8f31-30a7-848d-3af7bb1c5e55",
+      "dataFieldName": "fuel_level__accuracy",
+      "value": "1"
+    },
+    {
+      "key": "2bfaa641-c972-3816-ae7c-73459bcd673d",
+      "dataFieldName": "long_term_data_start_mileage",
+      "value": "39951"
+    },
+    {
+      "key": "0bf3d84a-9164-3d1c-8191-ca6dbce848a7",
+      "dataFieldName": "position_rear_right_door_window_lifter",
+      "value": "0"
+    },
+    {
+      "key": "9f55581a-4fa2-3570-9c9e-b80d210b9a42",
+      "dataFieldName": "short_term_data_mileage",
+      "value": "6"
+    },
+    {
+      "key": "a0ee824b-9a53-34ee-8107-3ed94684efa7",
+      "dataFieldName": "short_term_data_average_fuel_consumption",
+      "value": "0"
+    },
+    {
+      "key": "1416247c-df11-3685-b839-65d87cf97bcb",
+      "dataFieldName": "safe_state_rear_right_door",
+      "value": "3"
+    },
+    {
+      "key": "0543e58f-cd49-3e63-9e00-3b2d27043a25",
+      "dataFieldName": "position_rear_left_door_window_lifter",
+      "value": "0"
+    },
+    {
+      "key": "f5a56a87-0b03-3593-b66b-044f9006aea5",
+      "dataFieldName": "window_heating_error_code",
+      "value": "0"
+    },
+    {
+      "key": "f8bbe94d-06e1-3311-bf8f-c0c99cc67d48",
+      "dataFieldName": "parking_brake",
+      "value": "1"
+    },
+    {
+      "key": "d9f36adc-1840-37da-8ca1-7c2d789bcf9e",
+      "dataFieldName": "maintenance_interval_distance_until_oil_change",
+      "value": "-23500"
+    },
+    {
+      "key": "153e8c40-4c6c-3c17-a11b-0ecc35d55b81",
+      "dataFieldName": "cruising_range_combined",
+      "value": null
+    },
+    {
+      "key": "769f98fd-b821-367e-8434-e2c92fc5c52e",
+      "dataFieldName": "energy_flow",
+      "value": "off"
+    },
+    {
+      "key": "60fddd42-f4fe-3382-ba31-f04ce52d2ab4",
+      "dataFieldName": "position_front_left_door_window_lifter",
+      "value": "0"
+    },
+    {
+      "key": "cf28f7d9-6201-30b8-82e5-a461968d30dc",
+      "dataFieldName": "remaining_charging_time",
+      "value": "65535"
+    },
+    {
+      "key": "be03dca4-16fb-3072-82bd-17064bd423b9",
+      "dataFieldName": "tyre_pressure_actual_front_right",
+      "value": "1"
+    },
+    {
+      "key": "69729e19-7b1a-3189-8e11-b4b31ab7601a",
+      "dataFieldName": "tyre_pressure_differential_front_left",
+      "value": "1"
+    },
+    {
+      "key": "8a188a0b-24ea-34a9-9d6b-ed089547a128",
+      "dataFieldName": "remaining_charging_time_target_soc",
+      "value": "maxSOC"
+    },
+    {
+      "key": "14c7e318-fcea-3ed5-8284-a0309dc7527d",
+      "dataFieldName": "window_heating_state_front",
+      "value": "off"
+    },
+    {
+      "key": "3ba7c870-d2a7-3383-8a17-e4048a57a583",
+      "dataFieldName": "tank_current_level",
+      "value": "38.0"
+    },
+    {
+      "key": "ae0294b4-1286-3e98-a818-1485b8d88430",
+      "dataFieldName": "state_of_charge",
+      "value": "25"
+    },
+    {
+      "key": "5fb120bb-ab59-38fc-8e03-9ae197c7a1ae",
+      "dataFieldName": "state_rear_left_door_window_lifter",
+      "value": "3"
+    },
+    {
+      "key": "8ab83a99-d382-3ce1-9470-d98612e85066",
+      "dataFieldName": "tyre_pressure_required_front_right",
+      "value": "1"
+    },
+    {
+      "key": "c046a189-1068-3f8a-b00b-8bc4b9b4c6e0",
+      "dataFieldName": "tyre_pressure_required_spare_tyre",
+      "value": "1"
+    },
+    {
+      "key": "d48ccd21-a39f-33eb-989b-d81bd23fa766",
+      "dataFieldName": "state_of_hood",
+      "value": "0"
+    },
+    {
+      "key": "b43ff74c-2505-3a38-bf98-78c817fbaf96",
+      "dataFieldName": "scr_range",
+      "value": ""
+    },
+    {
+      "key": "1403559a-d939-3ec2-96c6-c2e8e6d0bd13",
+      "dataFieldName": "tyre_pressure_actual_spare_tyre",
+      "value": "1"
+    },
+    {
+      "key": "8d4cb2b4-a4f5-3285-9cc4-fc6709ada6fd",
+      "dataFieldName": "oil_level_total_max",
+      "value": "1.0"
+    },
+    {
+      "key": "053496dc-0a8e-3e0c-93fd-055e622d3f99",
+      "dataFieldName": "bem_level",
+      "value": "0"
+    },
+    {
+      "key": "0bb971a6-12ef-3382-9b99-5ed0a52f18e9",
+      "dataFieldName": "open_state_front_right_door",
+      "value": "2"
+    },
+    {
+      "key": "78fdf808-7917-335f-a44b-f4ad582f98bc",
+      "dataFieldName": "oil_level_dipstick_indicator_function",
+      "value": "0"
+    },
+    {
+      "key": "5fcf7d27-6b76-3de0-9ce9-f207370cdaff",
+      "dataFieldName": "state_front_right_door_window_lifter",
+      "value": "3"
+    },
+    {
+      "key": "60a4f436-5534-32f4-b4cc-b5a88a9d4b91",
+      "dataFieldName": "state_front_left_door_window_lifter",
+      "value": "3"
+    },
+    {
+      "key": "3b1bdf91-8e59-333a-93ed-f8e5a980bc96",
+      "dataFieldName": "short_term_data_average_electr_engine_consumption",
+      "value": "244"
+    },
+    {
+      "key": "f8eba56b-ee3f-3c48-b852-03c9b956053f",
+      "dataFieldName": "long_term_data_mileage",
+      "value": "257"
+    },
+    {
+      "key": "e1c6d420-b439-3de6-a5b7-d0b474cc2752",
+      "dataFieldName": "open_state_front_engine_bonnet",
+      "value": "3"
+    },
+    {
+      "key": "1e4d13b5-ce70-3429-a545-796f40775f92",
+      "dataFieldName": "tyre_pressure_required_front_left",
+      "value": "1"
+    },
+    {
+      "key": "d7d35c0a-706c-3f28-a61a-c3b002116a25",
+      "dataFieldName": "tyre_pressure_differential_rear_right",
+      "value": "1"
+    },
+    {
+      "key": "95380872-847c-39d7-857f-17cdea1579ce",
+      "dataFieldName": "locked_state_tailgate",
+      "value": "3"
+    },
+    {
+      "key": "bdf31409-b799-3969-8199-e305082aabf2",
+      "dataFieldName": "short_term_data_average_gas_consumption",
+      "value": "0"
+    },
+    {
+      "key": "3dedefab-8ded-3f5a-907f-d5e9970720bf",
+      "dataFieldName": "cruising_range_secondary_engine",
+      "value": "11"
+    },
+    {
+      "key": "c17ead4f-09b8-357f-ac2b-38c448ab88c4",
+      "dataFieldName": "parking_lights",
+      "value": "2"
+    },
+    {
+      "key": "8bad11dc-3a56-33ad-a4e9-23fdf117a88b",
+      "dataFieldName": "short_term_data_average_recuperation",
+      "value": "0"
+    },
+    {
+      "key": "41c0805c-43e5-313e-9dfb-356cb8d20f7c",
+      "dataFieldName": "mileage",
+      "value": "40208"
+    },
+    {
+      "key": "c111830c-f959-30d2-859a-ea996190d864",
+      "dataFieldName": "plug_state",
+      "value": "disconnected"
+    },
+    {
+      "key": "80e4fc45-1bf3-35eb-99b0-e956fd5ae5f0",
+      "dataFieldName": "active_warnings_in_instrument_cluster_fff",
+      "value": null
+    },
+    {
+      "key": "0f43f2e7-3556-36a9-8271-a60bc54afad8",
+      "dataFieldName": "echo",
+      "value": "echo"
+    },
+    {
+      "key": "a8bd75f4-e8d2-3c8b-973d-b2d15d9a1d46",
+      "dataFieldName": "state_sunroof_motor_hood_3",
+      "value": "1"
+    },
+    {
+      "key": "6c980d05-90d5-3948-8f35-2bd94fe9d1a2",
+      "dataFieldName": "active_warnings_in_instrument_cluster_feff_filtered",
+      "value": "1"
+    },
+    {
+      "key": "940aad2a-eb21-3e5c-b0c6-8ff4b395f917",
+      "dataFieldName": "safe_state_front_engine_bonnet",
+      "value": "3"
+    },
+    {
+      "key": "77838f59-786a-36fa-b1d4-47217a9fb40e",
+      "dataFieldName": "long_term_data_average_speed",
+      "value": "27"
+    },
+    {
+      "key": "d5e199c6-cdd5-31c3-b3d1-915c78662521",
+      "dataFieldName": "safe_state_rear_left_door",
+      "value": "3"
+    },
+    {
+      "key": "3c691e30-8c0e-3d8a-be41-7d2b770aeada",
+      "dataFieldName": "scope_potential_total",
+      "value": "0"
+    },
+    {
+      "key": "fcbbc9c5-d302-3019-a293-07a0123e3f53",
+      "dataFieldName": "tyre_pressure_required_rear_right",
+      "value": "1"
+    },
+    {
+      "key": "bc9bbc65-8461-30eb-88db-f94148552a20",
+      "dataFieldName": "open_state_front_left_door",
+      "value": "3"
+    },
+    {
+      "key": "06e25fe1-794b-378d-b1d1-eefd5324dbcf",
+      "dataFieldName": "short_term_data_range_gain_distance",
+      "value": "0"
+    },
+    {
+      "key": "f89ed652-d104-3fa6-b7e2-ab7543309e7b",
+      "dataFieldName": "hv_soc",
+      "value": "31"
+    },
+    {
+      "key": "a3368611-8c63-3b7d-9d19-148a464c7a7b",
+      "dataFieldName": "oil_level_actual_level",
+      "value": "100.0"
+    },
+    {
+      "key": "351e9e10-b831-391e-9fc4-ccacc8cd3eba",
+      "dataFieldName": "tyre_pressure_differential_spare_tyre",
+      "value": "1"
+    },
+    {
+      "key": "60c81e02-4825-3aab-8da8-b8b07f251623",
+      "dataFieldName": "open_state_rear_right_door",
+      "value": "3"
+    },
+    {
+      "key": "2d10f834-6e6e-3be0-9292-8c8cb9e09581",
+      "dataFieldName": "position_sunroof_motor_hood_1",
+      "value": "0"
+    },
+    {
+      "key": "df069cac-4bec-3894-afa4-bd344d3cd21c",
+      "dataFieldName": "short_term_data_zero_emission_distance",
+      "value": "0"
+    },
+    {
+      "key": "42b1c47b-e1d1-375f-a76f-32ab0177f03e",
+      "dataFieldName": "maintenance_interval__time_until_oil_change",
+      "value": "-494"
+    },
+    {
+      "key": "b6c6d710-53c3-3a5d-a23c-5a5141681d30",
+      "dataFieldName": "led_color",
+      "value": "none"
+    },
+    {
+      "key": "f0890c07-e62e-32dc-ab3b-80431f070b13",
+      "dataFieldName": "short_term_data_travel_time",
+      "value": "18"
+    },
+    {
+      "key": "55e0d40b-38ed-3cb5-9dcd-6193df6fc493",
+      "dataFieldName": "cruising_range_primary_engine",
+      "value": "210"
+    },
+    {
+      "key": "57cb3a0e-e9f1-32d1-bf19-dd5970230699",
+      "dataFieldName": "position_front_right_door_window_lifter",
+      "value": "0"
+    },
+    {
+      "key": "c4a26fd6-c08f-3921-bb8c-23fab6751c54",
+      "dataFieldName": "tyre_pressure_actual_front_left",
+      "value": "1"
+    },
+    {
+      "key": "5497c6f9-d22e-3bfc-886e-d1279a6be410",
+      "dataFieldName": "tyre_pressure_required_rear_left",
+      "value": "1"
+    },
+    {
+      "key": "97c7b448-13e7-3266-a6be-7487caf1a354",
+      "dataFieldName": "charging_mode",
+      "value": "off"
+    },
+    {
+      "key": "df531c6f-8897-3236-a760-5975322e7021",
+      "dataFieldName": "long_term_data_average_fuel_consumption",
+      "value": "14"
+    },
+    {
+      "key": "3ef13c1d-7e08-3cf4-b501-a8bda80cff78",
+      "dataFieldName": "state_rear_right_door_window_lifter",
+      "value": "3"
+    },
+    {
+      "key": "9da735bb-c5d5-39f8-bf53-0fa2a367aa8f",
+      "dataFieldName": "charging_state",
+      "value": "off"
+    },
+    {
+      "key": "21e084ad-51bf-3461-a521-49a544720c91",
+      "dataFieldName": "locked_state_front_right_door",
+      "value": "3"
+    },
+    {
+      "key": "3611b9e7-c6f3-39ef-b700-1f650dde7979",
+      "dataFieldName": "safe_state_front_right_door",
+      "value": "3"
+    },
+    {
+      "key": "92346806-a547-3014-b291-476c90558e53",
+      "dataFieldName": "safe_state_tailgate",
+      "value": "3"
+    },
+    {
+      "key": "4c81b70a-b304-3df3-bb25-53cbc10e7236",
+      "dataFieldName": "charging_state_error_code",
+      "value": "0"
+    },
+    {
+      "key": "6810b781-e54a-35e8-af98-fcdefb54bac6",
+      "dataFieldName": "outside_temperature",
+      "value": "3121"
+    },
+    {
+      "key": "78e92351-cf56-3c15-96d3-9b63d62ca618",
+      "dataFieldName": "oil_level_additional_oil_level",
+      "value": "100.0"
+    },
+    {
+      "key": "79f1709e-028d-3b3a-936e-bbef63b92969",
+      "dataFieldName": "long_term_data_average_electr_engine_consumption",
+      "value": "160"
+    },
+    {
+      "key": "b38e35e9-b2e9-38ce-9b14-27e6066ab888",
+      "dataFieldName": "state_service_hatch",
+      "value": "0"
+    },
+    {
+      "key": "fc0dab76-59ca-31bd-8845-e4b39d485b71",
+      "dataFieldName": "locked_state__rear_left_door",
+      "value": "3"
+    },
+    {
+      "key": "937bf8d6-bd3e-306e-af30-8a8a4cc14644",
+      "dataFieldName": "locked_state_front_engine_bonnet",
+      "value": "3"
+    },
+    {
+      "key": "173589ce-e437-3c6e-a0ec-6df704586fd7",
+      "dataFieldName": "trueness",
+      "value": null
+    },
+    {
+      "key": "c129d05d-de28-3490-a74a-27811b5e8e2e",
+      "dataFieldName": "cng_gas_level",
+      "value": null
+    },
+    {
+      "key": "dbb8f3b1-2bc9-3afc-a1d5-61f1eb04d1c4",
+      "dataFieldName": "open_state_tailgate",
+      "value": "3"
+    },
+    {
+      "key": "acdd25b5-8d20-3dbc-83f7-e5b8436e0362",
+      "dataFieldName": "last_battery_charger_update_trigger",
+      "value": "other"
+    },
+    {
+      "key": "60bc0937-f5a7-3809-9535-9a7942e5dd94",
+      "dataFieldName": "lock_state",
+      "value": "unlocked"
+    },
+    {
+      "key": "d2ad181b-511a-37d0-8109-e676e68c86b2",
+      "dataFieldName": "long_term_data_travel_time",
+      "value": "579"
+    },
+    {
+      "key": "6d90f88e-b7bf-3b1e-a306-c0e1c0c29c6e",
+      "dataFieldName": "state_spoiler",
+      "value": "1"
+    },
+    {
+      "key": "9c390ebd-cc97-3f18-8e47-82dcc44a514e",
+      "dataFieldName": "led_state",
+      "value": "off"
+    },
+    {
+      "key": "1c62bf0a-8088-332c-9399-3b8cb0573099",
+      "dataFieldName": "remaining_climatisation_time",
+      "value": "10"
+    },
+    {
+      "key": "bf62dd10-b184-3425-a64c-c50b09420bc3",
+      "dataFieldName": "open_state_rear_left_door",
+      "value": "3"
+    },
+    {
+      "key": "cff28415-8084-34e0-ad91-db191e5ff3b6",
+      "dataFieldName": "state_sunroof_motor_hood_1",
+      "value": "3"
+    },
+    {
+      "key": "fd600221-7965-3396-96d7-82a840a2831c",
+      "dataFieldName": "maintenance_interval__time_until_inspection",
+      "value": "-129"
+    },
+    {
+      "key": "a59fa6dd-c0e8-35af-afc0-1f411c33c78c",
+      "dataFieldName": "tyre_pressure_differential_rear_left",
+      "value": "1"
+    },
+    {
+      "key": "61118afe-a4e4-3750-b1ad-2b38ff1d349b",
+      "dataFieldName": "charging_reason_trigger",
+      "value": "immediate"
+    },
+    {
+      "key": "920f460c-123e-3088-8d36-ba349b11f399",
+      "dataFieldName": "window_heating_state_rear",
+      "value": "off"
+    },
+    {
+      "key": "1503760b-5570-3001-8ffc-1bb6f464948e",
+      "dataFieldName": "fuel_level_current_level",
+      "value": "37"
+    }
+  ]
+}

--- a/tests/test_brands_and_decode.py
+++ b/tests/test_brands_and_decode.py
@@ -93,6 +93,24 @@ def test_door_window_light_decoding():
     assert Lights.LightState(_light_code(2)) is Lights.LightState.OFF
 
 
+def test_window_opening_percentage_decoding():
+    """Window opening: percentage preferred (closed/ajar/open), state_* as fallback."""
+    from carconnectivity.windows import Windows
+    from carconnectivity_connectors.vw_eu_data_act.connector import _window_open_code
+
+    # percentage drives closed (0) / ajar (1..99) / open (100)
+    assert _window_open_code(0, None) == 'closed'
+    assert _window_open_code(42, None) == 'ajar'
+    assert _window_open_code(100, None) == 'open'
+    assert _window_open_code("0", None) == 'closed'   # portal sends strings
+    # out-of-range / missing percentage falls back to the coarse state code
+    assert _window_open_code(None, 2) == 'open'
+    assert _window_open_code(None, 3) == 'closed'
+    assert _window_open_code(None, None) is None
+    # decoded strings are valid enum values, including ajar
+    assert Windows.OpenState(_window_open_code(42, None)) is Windows.OpenState.AJAR
+
+
 def test_dataset_parses_maintenance_and_climate_fields():
     ds = Dataset.from_json({"vin": "V", "Data": [
         {"key": "a", "dataFieldName": "maintenance_interval__time_until_inspection", "value": "-127"},

--- a/tests/test_brands_and_decode.py
+++ b/tests/test_brands_and_decode.py
@@ -1,0 +1,71 @@
+"""Offline tests for multi-brand support and the added decode helpers.
+
+Pure tests: no network, no CarConnectivity garage. They cover the per-brand
+OIDC client_id / manufacturer resolution and the deci-Kelvin / maintenance /
+climatisation field decoding added to the connector.
+"""
+from datetime import datetime, timedelta, timezone
+
+from carconnectivity_connectors.vw_eu_data_act.brands import BRANDS, resolve_brand
+from carconnectivity_connectors.vw_eu_data_act.client import EudaApiClient
+from carconnectivity_connectors.vw_eu_data_act.dataset import (
+    Dataset, decikelvin_to_celsius,
+)
+
+
+def test_every_brand_has_distinct_identity():
+    for key, brand in BRANDS.items():
+        assert brand.key == key
+        assert brand.client_id.endswith("@apps_vw-dilab_com")
+        assert brand.manufacturer
+
+
+def test_resolve_brand_keys_aliases_and_default():
+    assert resolve_brand("CUPRA").manufacturer == "Cupra"
+    assert resolve_brand("seat").manufacturer == "SEAT"           # case-insensitive
+    assert resolve_brand("vw").key == "VOLKSWAGEN_PASSENGER_CARS"  # alias
+    assert resolve_brand("audi").client_id.startswith("cc29b87a")
+    assert resolve_brand(None).key == "VOLKSWAGEN_PASSENGER_CARS"  # default
+    assert resolve_brand("nope").key == "VOLKSWAGEN_PASSENGER_CARS"  # unknown -> default
+
+
+def test_brand_client_ids_match_expected():
+    assert resolve_brand("SKODA").client_id.startswith("3ea88bf9")
+    assert resolve_brand("BENTLEY").client_id.startswith("d38aac0f")
+    # SEAT and Cupra share the portal default client_id.
+    assert resolve_brand("SEAT").client_id == resolve_brand("CUPRA").client_id
+
+
+def test_client_uses_per_brand_client_id():
+    cupra = EudaApiClient(email="x", password="y", brand="CUPRA")
+    assert cupra._client_id == resolve_brand("CUPRA").client_id
+    assert cupra._state.endswith("__CUPRA")
+    audi = EudaApiClient(email="x", password="y", brand="AUDI")
+    assert audi._client_id.startswith("cc29b87a")
+
+
+def test_decikelvin_to_celsius():
+    assert decikelvin_to_celsius(3061) == 33.0
+    assert decikelvin_to_celsius(3121) == 39.0
+    assert decikelvin_to_celsius(None) is None
+    assert decikelvin_to_celsius("oops") is None
+
+
+def test_dataset_parses_maintenance_and_climate_fields():
+    ds = Dataset.from_json({"vin": "V", "Data": [
+        {"key": "a", "dataFieldName": "maintenance_interval__time_until_inspection", "value": "-127"},
+        {"key": "b", "dataFieldName": "maintenance_interval_distance_until_inspection", "value": "-23500"},
+        {"key": "c", "dataFieldName": "remaining_climatisation_time", "value": "10"},
+        {"key": "d", "dataFieldName": "outside_temperature", "value": "3061"},
+    ]})
+    insp_days = ds.value_of("maintenance_interval__time_until_inspection")
+    assert insp_days == -127
+    # signed countdown -> due date (negative = remaining)
+    captured = datetime(2026, 6, 26, 11, 0, tzinfo=timezone.utc)
+    due_at = captured + timedelta(days=-insp_days)
+    assert due_at.date().isoformat() == "2026-10-31"
+    # distance: remaining km (abs of the signed value)
+    assert abs(ds.value_of("maintenance_interval_distance_until_inspection")) == 23500
+    # flat climatisation time is integer minutes
+    assert ds.value_of("remaining_climatisation_time") == 10
+    assert decikelvin_to_celsius(ds.value_of("outside_temperature")) == 33.0

--- a/tests/test_brands_and_decode.py
+++ b/tests/test_brands_and_decode.py
@@ -70,6 +70,29 @@ def test_flat_charging_values_map_to_carconnectivity_enums():
     assert round(157 / 10, 1) == 15.7
 
 
+def test_door_window_light_decoding():
+    """Portal open/lock/light codes decode to valid CarConnectivity enum values."""
+    from carconnectivity.doors import Doors
+    from carconnectivity.windows import Windows
+    from carconnectivity.lights import Lights
+    from carconnectivity_connectors.vw_eu_data_act.connector import (
+        _light_code, _lock_code, _open_code,
+    )
+
+    # open encoding: 2 = open/active, 3 = closed/inactive, 0/1 = invalid
+    assert _open_code(2) == 'open' and _open_code(3) == 'closed'
+    assert _open_code(0) is None and _open_code(1) is None
+    assert _lock_code(2) == 'locked' and _lock_code(3) == 'unlocked'
+    # lights encoding: 2 = off, 3/4/5 = on, 0/1 = invalid
+    assert _light_code(2) == 'off' and _light_code(3) == 'on' and _light_code(5) == 'on'
+    assert _light_code(1) is None
+    # decoded strings are valid enum values
+    assert Doors.OpenState(_open_code(3)) is Doors.OpenState.CLOSED
+    assert Doors.LockState(_lock_code(2)) is Doors.LockState.LOCKED
+    assert Windows.OpenState(_open_code(2)) is Windows.OpenState.OPEN
+    assert Lights.LightState(_light_code(2)) is Lights.LightState.OFF
+
+
 def test_dataset_parses_maintenance_and_climate_fields():
     ds = Dataset.from_json({"vin": "V", "Data": [
         {"key": "a", "dataFieldName": "maintenance_interval__time_until_inspection", "value": "-127"},

--- a/tests/test_brands_and_decode.py
+++ b/tests/test_brands_and_decode.py
@@ -51,6 +51,25 @@ def test_decikelvin_to_celsius():
     assert decikelvin_to_celsius("oops") is None
 
 
+def test_flat_charging_values_map_to_carconnectivity_enums():
+    """The portal's flat charging strings must be valid CarConnectivity enum values."""
+    from carconnectivity.charging import Charging
+    from carconnectivity.charging_connector import ChargingConnector
+    from carconnectivity.units import EnergyConsumption
+
+    assert Charging.ChargingState("charging") is Charging.ChargingState.CHARGING
+    assert Charging.ChargingState("off") is Charging.ChargingState.OFF
+    assert Charging.ChargingType("ac") is Charging.ChargingType.AC
+    assert ChargingConnector.ChargingConnectorConnectionState("connected") \
+        is ChargingConnector.ChargingConnectorConnectionState.CONNECTED
+    assert ChargingConnector.ChargingConnectorConnectionState("disconnected") \
+        is ChargingConnector.ChargingConnectorConnectionState.DISCONNECTED
+    assert ChargingConnector.ExternalPower("available") is ChargingConnector.ExternalPower.AVAILABLE
+    assert EnergyConsumption.KWH100KM.value == "kWh/100km"
+    # long-term electric consumption: kWh/1000km -> kWh/100km
+    assert round(157 / 10, 1) == 15.7
+
+
 def test_dataset_parses_maintenance_and_climate_fields():
     ds = Dataset.from_json({"vin": "V", "Data": [
         {"key": "a", "dataFieldName": "maintenance_interval__time_until_inspection", "value": "-127"},

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -877,3 +877,46 @@ def test_charge_mode_absent_leaves_attribute_unset(connector):
 
     v = garage.get_vehicle(VIN)
     assert getattr(v.charging.settings, "charge_mode", None) is None
+
+
+def test_flat_charge_power_and_rate_deci_scaling(connector):
+    """Flat-format charge power/rate are deci integers (99 -> 9.9)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "battery_state_report.soc", "value": "50"},
+            {"key": "k2", "dataFieldName": "charging_power", "value": "99"},
+            {"key": "k3", "dataFieldName": "actual_charge_rate", "value": "99"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.charging.power.value == 9.9   # 99 / 10 kW
+    assert v.charging.rate.value == 9.9    # 99 / 10 (km/h default)
+
+
+def test_dotted_charge_power_takes_precedence_over_flat(connector):
+    """The dotted battery_state_report.charge_power is already kW: when present,
+    the flat deci-kW field must be ignored (no mis-scaling)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "battery_state_report.soc", "value": "50"},
+            {"key": "k2", "dataFieldName": "battery_state_report.charge_power", "value": "7.4"},
+            {"key": "k3", "dataFieldName": "charging_power", "value": "99"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).charging.power.value == 7.4   # dotted wins, no /10

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -686,3 +686,42 @@ def test_flat_data_egolf_payload_promotes_and_maps(connector):
     assert drive.level.value == 26
     assert drive.range.value == 67
     assert drive.range.unit == Length.KM
+
+
+def test_phev_promotes_to_hybrid_and_maps_both_drives(connector):
+    """A dataset with both battery and fuel fields -> HybridVehicle with two drives."""
+    from carconnectivity.vehicle import HybridVehicle
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "a", "dataFieldName": "state_of_charge", "value": "25"},
+        {"key": "b", "dataFieldName": "cruising_range_secondary_engine", "value": "11"},
+        {"key": "c", "dataFieldName": "long_term_data_average_electr_engine_consumption", "value": "160"},
+        {"key": "d", "dataFieldName": "fuel_level_current_level", "value": "37"},
+        {"key": "e", "dataFieldName": "cruising_range_primary_engine", "value": "210"},
+        {"key": "f", "dataFieldName": "long_term_data_average_fuel_consumption", "value": "14"},
+    ]})
+    connector._map_dataset(VIN, ds)
+    v = garage.get_vehicle(VIN)
+    assert isinstance(v, HybridVehicle)
+    electric = v.get_electric_drive()
+    combustion = v.get_combustion_drive()
+    assert electric.level.value == 25 and electric.range.value == 11
+    assert electric.consumption.value == 16.0   # 160 kWh/1000km -> 16.0 kWh/100km
+    assert combustion.level.value == 37 and combustion.range.value == 210
+    assert combustion.consumption.value == 1.4   # 14 L/1000km -> 1.4 L/100km
+
+
+def test_pure_ev_stays_electric_not_hybrid(connector):
+    """A battery-only dataset stays a pure electric vehicle (no combustion drive)."""
+    from carconnectivity.vehicle import CombustionVehicle
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "a", "dataFieldName": "battery_state_report.soc", "value": "69"},
+        {"key": "b", "dataFieldName": "range", "value": "312"},
+    ]})
+    connector._map_dataset(VIN, ds)
+    v = garage.get_vehicle(VIN)
+    assert not isinstance(v, CombustionVehicle)
+    assert v.get_electric_drive().level.value == 69

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -725,3 +725,38 @@ def test_pure_ev_stays_electric_not_hybrid(connector):
     v = garage.get_vehicle(VIN)
     assert not isinstance(v, CombustionVehicle)
     assert v.get_electric_drive().level.value == 69
+
+
+PHEV_SAMPLE = os.path.join(os.path.dirname(__file__), "phev_sample_dataset.json")
+
+
+def test_phev_real_world_sample(connector):
+    """Full mapping against an anonymised real flat SEAT Leon PHEV dataset."""
+    from carconnectivity.vehicle import HybridVehicle
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    payload = json.load(open(PHEV_SAMPLE, "r", encoding="utf-8"))
+    payload["vin"] = VIN
+    connector._map_dataset(VIN, Dataset.from_json(payload))
+    v = garage.get_vehicle(VIN)
+
+    assert isinstance(v, HybridVehicle)
+    # primary slot = petrol (combustion), secondary = electric (seatcupra convention)
+    primary = v.drives.drives["primary"]
+    secondary = v.drives.drives["secondary"]
+    assert str(primary.type.value) == "Type.GASOLINE"
+    assert str(secondary.type.value) == "Type.ELECTRIC"
+    assert primary.range.value == 210 and primary.level.value == 37        # petrol
+    assert secondary.range.value == 11 and secondary.level.value == 25     # electric
+    assert primary.consumption.value == 1.4                               # L/100km
+    assert secondary.consumption.value == 16.0                            # kWh/100km
+    # vehicle-level
+    assert v.odometer.value == 40208
+    assert v.outside_temperature.value == 39.0
+    # status objects populated
+    assert len(v.doors.doors) == 6
+    assert v.doors.doors["front_right"].open_state.value.value == "open"
+    assert len(v.windows.windows) == 5
+    assert v.lights.lights["parking"].light_state.value.value == "off"
+    # maintenance distance preserved
+    assert v.maintenance.inspection_due_after.value == 23500

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -22,7 +22,10 @@ import requests
 from carconnectivity.units import Length, Speed
 
 from carconnectivity_connectors.vw_eu_data_act.client import ApiError, EudaApiClient
-from carconnectivity_connectors.vw_eu_data_act.connector import Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS
+from carconnectivity_connectors.vw_eu_data_act.connector import (
+    Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS,
+    _charge_mode, _charge_mode_flat, VWEudaChargeMode,
+)
 from carconnectivity_connectors.vw_eu_data_act.dataset import Dataset
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
 
@@ -800,3 +803,77 @@ def test_phev_real_world_sample(connector):
     assert v.lights.lights["parking"].light_state.value.value == "off"
     # maintenance distance preserved
     assert v.maintenance.inspection_due_after.value == 23500
+
+
+def test_charge_mode_normalisation():
+    """_charge_mode maps the data-dictionary tokens (with or without the
+    CHARGE_MODE_SELECTION_ prefix) to the enum, None stays None, unknown -> UNKNOWN."""
+    assert _charge_mode(None) is None
+    assert _charge_mode("") is None
+    assert _charge_mode("CHARGE_MODE_SELECTION_TIMERCHARGING") == VWEudaChargeMode.TIMER
+    assert _charge_mode("CHARGE_MODE_SELECTION_TIMER_CHARGING_CLIMATIZATION") \
+        == VWEudaChargeMode.TIMER_CHARGING_WITH_CLIMATISATION
+    assert _charge_mode("CHARGE_MODE_SELECTION_PREFERRED_CHARGING_TIMES") \
+        == VWEudaChargeMode.PREFERRED_CHARGING_TIMES
+    assert _charge_mode("manual") == VWEudaChargeMode.MANUAL
+    assert _charge_mode("timer") == VWEudaChargeMode.TIMER
+    assert _charge_mode("something_new") == VWEudaChargeMode.UNKNOWN
+
+
+def test_charge_mode_dotted_mapping(connector):
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "settings.charge_mode_selection",
+             "value": "CHARGE_MODE_SELECTION_PREFERRED_CHARGING_TIMES"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.charging.settings.charge_mode.value == VWEudaChargeMode.PREFERRED_CHARGING_TIMES
+
+
+def test_charge_mode_flat_options_mapping(connector):
+    """Flat/continuous format: the active per-option boolean wins."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "charge_mode_selection_options.manual", "value": "false"},
+            {"key": "k2", "dataFieldName": "charge_mode_selection_options.timer_charging", "value": "true"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.charging.settings.charge_mode.value == VWEudaChargeMode.TIMER
+
+
+def test_charge_mode_absent_leaves_attribute_unset(connector):
+    """A vehicle that does not report the field gets no charge_mode attribute
+    (no regression on brands/platforms without it, e.g. many VWs)."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "k1", "dataFieldName": "mileage.value", "value": "100"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert getattr(v.charging.settings, "charge_mode", None) is None

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -727,6 +727,46 @@ def test_pure_ev_stays_electric_not_hybrid(connector):
     assert v.get_electric_drive().level.value == 69
 
 
+def test_diesel_creates_dieseldrive_and_maps_adblue(connector):
+    """A diesel dataset (numeric scr_range) must create a DieselDrive, because
+    adblue_range exists only there. Writing it on a plain CombustionDrive (the
+    previous behaviour) raised AttributeError on real diesels."""
+    from carconnectivity.drive import DieselDrive
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "a", "dataFieldName": "fuel_level_current_level", "value": "60"},
+        {"key": "b", "dataFieldName": "cruising_range_primary_engine", "value": "700"},
+        {"key": "c", "dataFieldName": "scr_range", "value": "9000"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    drive = garage.get_vehicle(VIN).get_combustion_drive()
+    assert isinstance(drive, DieselDrive)
+    assert str(drive.type.value) == "Type.DIESEL"
+    assert drive.adblue_range.value == 9000
+    assert drive.adblue_range.unit == Length.KM
+
+
+def test_petrol_empty_scr_range_stays_combustion_no_crash(connector):
+    """Petrol/PHEV cars also carry the scr_range field but report it as an empty
+    string. That must NOT be read as diesel (no DieselDrive) and must not raise."""
+    from carconnectivity.drive import CombustionDrive, DieselDrive
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "a", "dataFieldName": "fuel_level_current_level", "value": "37"},
+        {"key": "b", "dataFieldName": "cruising_range_primary_engine", "value": "210"},
+        {"key": "c", "dataFieldName": "scr_range", "value": ""},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    drive = garage.get_vehicle(VIN).get_combustion_drive()
+    assert isinstance(drive, CombustionDrive)
+    assert not isinstance(drive, DieselDrive)
+    assert str(drive.type.value) == "Type.GASOLINE"
+
+
 PHEV_SAMPLE = os.path.join(os.path.dirname(__file__), "phev_sample_dataset.json")
 
 


### PR DESCRIPTION
## Summary

Flat-format PHEV payloads (Passat/Tayron/Golf reports, and my SEAT Leon) expose charge power as `charging_power` and charge rate as `actual_charge_rate`, both deci integers (99 -> 9.9). The connector only handled the dotted `battery_state_report.charge_power`/`charge_rate`, so on a flat-format vehicle both values were simply missing while charging.

## Dependencies

- **Stacked on #16** (`feat/multi-brand-and-decode`), which provides the flat-format charging mapping this extends. Merge #16 first; until then this PR's diff includes #16's commits.

## Changes

- Map `charging_power` -> `charging.power` and `actual_charge_rate` -> `charging.rate` with the /10 scaling, the rate unit read from the flat `charge_rate_unit` companion.
- Guarded on the dotted variant being absent: the existing dotted behaviour (already kW) is untouched and keeps precedence.
- `charging_power`, `actual_charge_rate`, `charge_rate_unit` added to `KNOWN_MAPPED_FIELDS`.
- Tests: deci scaling and dotted-over-flat precedence.

## Validation

Offline suite on this branch: 43 passed.