### PR TITLE
feat(dataset): prefer the highest odometer slot among equally-fresh readings

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -549,8 +549,10 @@ class Connector(BaseConnector):
 
         # Odometer (mileage.value). The portal reports km or miles depending on
         # the vehicle; the unit comes from the companion mileage.unit enum, with
-        # km as the fallback when that field is absent.
-        mileage = dataset.value_of('mileage.value')
+        # km as the fallback when that field is absent. Prefer the highest slot
+        # among equally-fresh readings so a lagging snapshot never makes the
+        # (monotonic) odometer momentarily read low.
+        mileage = dataset.freshest_max_value_of('mileage.value')
         if mileage is not None:
             mileage_unit = Length.MI if resolve_distance_unit(dataset.value_of('mileage.unit')) == 'mi' else Length.KM
             vehicle.odometer._set_value(value=mileage, measured=captured_at, unit=mileage_unit)  # pylint: disable=protected-access
@@ -591,7 +593,7 @@ class Connector(BaseConnector):
                 drive.range.precision = 1
 
             # Some flat-format datasets only provide a bare 'mileage' field.
-            flat_mileage = dataset.value_of('mileage')
+            flat_mileage = dataset.freshest_max_value_of('mileage')
             if flat_mileage is not None and mileage is None:
                 vehicle.odometer._set_value(value=flat_mileage, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
                 vehicle.odometer.precision = 1

--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -202,6 +202,7 @@ class DataPoint:
     key: str
     field_name: str
     raw_value: str
+    timestamp: Optional[datetime] = None  # the field's own timestampUtc (when the car reported it)
 
     @property
     def value(self):
@@ -212,6 +213,30 @@ class DataPoint:
         mapping (which keys off the label string) keeps working.
         """
         return resolve_enum_index(self.field_name, parse_value(self.raw_value))
+
+
+def _freshness_key(dp: "DataPoint"):
+    """Sort key for ``min()`` that picks the freshest data point.
+
+    Orders timestamped points ahead of timestamp-less ones, newest first, with
+    the smallest UUID as a stable tie-break (so selection never flip-flops when
+    the portal reshuffles the array or two readings share a timestamp).
+    """
+    if dp.timestamp is not None:
+        return (0, -dp.timestamp.timestamp(), dp.key)
+    return (1, 0.0, dp.key)
+
+
+def _at_least_as_fresh(new: "DataPoint", cur: "DataPoint") -> bool:
+    """Whether ``new`` should replace ``cur`` while merging datasets in list order.
+
+    A timestamped reading wins over an older or timestamp-less one; on equal
+    timestamps (or when both lack one) the later dataset in list order wins,
+    preserving the previous behaviour for fields that carry no ``timestampUtc``.
+    """
+    if new.timestamp is not None:
+        return cur.timestamp is None or new.timestamp >= cur.timestamp
+    return cur.timestamp is None
 
 
 @dataclass
@@ -233,7 +258,8 @@ class Dataset:
             if not key:
                 continue
             field_name = item.get("dataFieldName") or key
-            dp = DataPoint(key=key, field_name=field_name, raw_value=item.get("value", ""))
+            dp = DataPoint(key=key, field_name=field_name, raw_value=item.get("value", ""),
+                           timestamp=parse_timestamp(item.get("timestampUtc")))
             points[key] = dp
             if field_name == "car_captured_time":
                 ts = parse_timestamp(dp.raw_value)
@@ -257,7 +283,10 @@ class Dataset:
         for ds in datasets:
             for field_name in ds.field_names:
                 dp = ds.by_field(field_name)
-                if dp is not None:
+                if dp is None:
+                    continue
+                cur = latest.get(field_name)
+                if cur is None or _at_least_as_fresh(dp, cur):
                     latest[field_name] = dp
             if ds.captured_at and (merged_captured is None or ds.captured_at > merged_captured):
                 merged_captured = ds.captured_at
@@ -272,13 +301,15 @@ class Dataset:
         The portal merges several report snapshots into one flat array with no
         ordering guarantee and no way to tell which value is "live", so a field
         like ``charging_state_report.current_charge_state`` can appear several
-        times under different UUIDs with conflicting values. We pick the entry
-        with the smallest ``key`` (UUID): an arbitrary but *stable* choice, so a
-        mapped attribute consistently tracks the same data point across refreshes
-        instead of flip-flopping when the portal reshuffles the array.
+        times under different UUIDs with conflicting values. We pick the
+        **freshest** reading (latest ``timestampUtc``); when timestamps are equal
+        or absent we fall back to the smallest ``key`` (UUID): an arbitrary but
+        *stable* choice, so a mapped attribute consistently tracks the same data
+        point across refreshes instead of flip-flopping when the portal reshuffles
+        the array.
         """
         matches = [dp for dp in self.points.values() if dp.field_name == field_name]
-        return min(matches, key=lambda dp: dp.key) if matches else None
+        return min(matches, key=_freshness_key) if matches else None
 
     def value_of(self, field_name: str):
         """Return the typed value of ``field_name`` or ``None`` if absent."""

--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -316,6 +316,33 @@ class Dataset:
         dp = self.by_field(field_name)
         return dp.value if dp is not None else None
 
+    def freshest_max_value_of(self, field_name: str):
+        """Like :meth:`value_of`, but among equally-fresh slots prefer the highest
+        numeric value.
+
+        A single dataset can carry several snapshots of one field under different
+        UUIDs that share one freshness (e.g. two ``mileage.value`` readings lagging
+        each other at the same ``car_captured_time``). The arbitrary smallest-UUID
+        tie-break in :meth:`by_field` can then pick the lower reading, making a
+        monotonic field like the odometer momentarily read low. Used for the
+        odometer; ``by_field``/``value_of`` keep their stable behaviour elsewhere.
+        """
+        matches = [dp for dp in self.points.values() if dp.field_name == field_name]
+        if not matches:
+            return None
+
+        def _rank(dp: "DataPoint"):  # freshness rank without the UUID tie-break
+            return (0, -dp.timestamp.timestamp()) if dp.timestamp is not None else (1, 0.0)
+
+        best_rank = min(_rank(dp) for dp in matches)
+        freshest = [dp for dp in matches if _rank(dp) == best_rank]
+        numeric = [dp.value for dp in freshest
+                   if isinstance(dp.value, (int, float)) and not isinstance(dp.value, bool)]
+        if numeric:
+            return max(numeric)
+        # Non-numeric field: keep the stable by_field choice among the freshest.
+        return min(freshest, key=_freshness_key).value
+
     @property
     def field_names(self) -> set:
         return {dp.field_name for dp in self.points.values()}

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -280,6 +280,47 @@ def test_by_field_picks_smallest_uuid_deterministically():
         "charging_state_report.current_charge_state") == "CHARGE_STATE_OFF"
 
 
+def test_by_field_prefers_freshest_timestamp():
+    """When a field appears several times, the reading with the latest
+    timestampUtc wins, even if a staler reading has a smaller UUID (which the
+    old smallest-UUID rule would have picked)."""
+    data = [
+        {"key": "aaaa", "dataFieldName": "oil_level_actual_level",
+         "value": "100.0", "timestampUtc": "2026-06-23T15:14:12.000Z"},
+        {"key": "zzzz", "dataFieldName": "oil_level_actual_level",
+         "value": "87.5", "timestampUtc": "2026-06-25T10:37:14.000Z"},
+    ]
+    assert Dataset.from_json({"vin": VIN, "Data": data}).value_of("oil_level_actual_level") == 87.5
+
+
+def test_merge_prefers_freshest_timestamp_regardless_of_list_order():
+    """A stale reading in a later-listed dataset must not override a fresher one.
+    Reproduces the oil-level bug: oil 100.0 measured 2026-06-23 must lose to oil
+    87.5 measured 2026-06-25 whatever the merge order."""
+    fresh = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "oil_level_actual_level",
+         "value": "87.5", "timestampUtc": "2026-06-25T10:37:14.000Z"},
+    ]})
+    stale = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k2", "dataFieldName": "oil_level_actual_level",
+         "value": "100.0", "timestampUtc": "2026-06-23T15:14:12.000Z"},
+    ]})
+    assert Dataset.merge([fresh, stale]).value_of("oil_level_actual_level") == 87.5
+    assert Dataset.merge([stale, fresh]).value_of("oil_level_actual_level") == 87.5
+
+
+def test_merge_timestampless_field_keeps_list_order():
+    """Fields without timestampUtc keep the previous behaviour: the later dataset
+    in list order wins (no regression for timestamp-less fields)."""
+    first = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k1", "dataFieldName": "charging_state", "value": "off"},
+    ]})
+    second = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "k2", "dataFieldName": "charging_state", "value": "charging"},
+    ]})
+    assert Dataset.merge([first, second]).value_of("charging_state") == "charging"
+
+
 def test_filename_timestamp_both_layouts():
     """createdOn-less listings fall back to the filename timestamp; both
     "TIMESTAMP_VIN.zip" and "VIN_TIMESTAMP.zip" layouts must parse, else the

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -727,3 +727,50 @@ def test_flat_data_egolf_payload_promotes_and_maps(connector):
     assert drive.level.value == 26
     assert drive.range.value == 67
     assert drive.range.unit == Length.KM
+
+
+def test_freshest_max_value_prefers_highest_equal_freshness():
+    """Two equally-fresh mileage slots: by_field takes the stable smallest-UUID
+    (which can be the lower reading); freshest_max_value_of prefers the highest."""
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "aaaaaaaa-0000-0000-0000-000000000000", "dataFieldName": "mileage.value",
+             "value": "70876", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+            {"key": "bbbbbbbb-0000-0000-0000-000000000000", "dataFieldName": "mileage.value",
+             "value": "70908", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        ]
+    })
+    assert ds.by_field("mileage.value").value == 70876          # arbitrary stable choice
+    assert ds.freshest_max_value_of("mileage.value") == 70908   # highest slot wins
+
+
+def test_freshest_max_value_single_and_absent():
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [{"key": "k1", "dataFieldName": "mileage.value", "value": "12345"}],
+    })
+    assert ds.freshest_max_value_of("mileage.value") == 12345
+    assert ds.freshest_max_value_of("does.not.exist") is None
+
+
+def test_odometer_prefers_highest_slot(connector):
+    """The mapped odometer never reads low when a dataset carries several
+    equally-fresh mileage slots."""
+    garage = connector.car_connectivity.garage
+    vehicle = VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector)
+    garage.add_vehicle(VIN, vehicle)
+
+    ds = Dataset.from_json({
+        "vin": VIN,
+        "Data": [
+            {"key": "aaaaaaaa-0000-0000-0000-000000000000", "dataFieldName": "mileage.value",
+             "value": "70876", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+            {"key": "bbbbbbbb-0000-0000-0000-000000000000", "dataFieldName": "mileage.value",
+             "value": "70908", "timestampUtc": "2026-05-31T14:11:43.000Z"},
+        ]
+    })
+
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).odometer.value == 70908


### PR DESCRIPTION
## Summary

A single dataset can carry several snapshots of `mileage.value` under different UUIDs sharing one freshness (two readings lagging each other at the same `car_captured_time`). The stable smallest-UUID tie-break can then pick the lower reading, making the odometer momentarily read low and jump back. The odometer now prefers the highest value among the equally-fresh slots, so a monotonic field stays monotonic.

## Dependencies

- **Stacked on #18** (`fix/freshest-value-main`), which provides the freshness-based selection this refines. Merge #18 first; until then this PR's diff includes #18's commit.
- Independent of #16.

## Changes

- New `Dataset.freshest_max_value_of`: among the freshest slots of a field, return the highest numeric value; non-numeric fields keep the stable `by_field` choice. Used for the odometer only, `by_field`/`value_of` keep their stable behaviour everywhere else.
- Connector reads the odometer through it.
- Tests: highest-slot preference end to end on the mapped odometer, single/absent field edge cases.

## Validation

Offline suite on this branch: 38 passed.