### PR TITLE
fix(client): judge login by the auth callback, not the landing page status

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/client.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/client.py
@@ -166,6 +166,21 @@ def _login_error(html: str) -> Optional[str]:
     return str(err) if err else None
 
 
+def _passed_portal_callback(resp: requests.Response) -> bool:
+    """Return True if the redirect chain went through the portal login callback.
+
+    ``/services/callbacklogin`` is the hop that exchanges the OIDC code and sets
+    the portal session cookies, so reaching it means authentication completed
+    whatever the final localized landing page returns.
+    """
+    portal_host = urlparse(BASE_URL).netloc
+    for hop in list(resp.history) + [resp]:
+        parsed = urlparse(hop.url)
+        if parsed.netloc == portal_host and parsed.path.startswith("/services/callbacklogin"):
+            return True
+    return False
+
+
 def _extract_vins(payload) -> List[dict]:
     """Best-effort extraction of vehicles from the (undocumented) vehicles body.
 
@@ -302,13 +317,37 @@ class EudaApiClient:
             headers={"Referer": authenticate_url},
             timeout=self._timeout,
         )
+        self._finish_login(resp)
+
+    def _finish_login(self, resp: requests.Response) -> None:
+        """Judge the end of the credentials redirect chain and confirm the session.
+
+        The chain ends on a localized CMS landing page whose availability is
+        unrelated to authentication - it simply does not exist for some locales
+        (e.g. country "ch", issue #29). Once the chain has passed the portal's
+        /services/callbacklogin hop the session cookies are set, so the landing
+        page status alone must not fail the login.
+        """
         landing = resp.url
         landing_html = resp.text
         if resp.status_code >= 400:
-            LOG.debug("login step4: HTTP %s body[:500]=%s", resp.status_code, landing_html[:500])
-            err = _login_error(landing_html)
-            raise AuthError(err or f"Login rejected (HTTP {resp.status_code})")
+            if not _passed_portal_callback(resp):
+                LOG.debug("login step4: HTTP %s body[:500]=%s", resp.status_code, landing_html[:500])
+                err = _login_error(landing_html)
+                raise AuthError(err or f"Login rejected (HTTP {resp.status_code})")
+            LOG.debug("login step4: landing page HTTP %s ignored (callbacklogin passed): %s",
+                      resp.status_code, landing)
         LOG.debug("login step4: landed on %s", landing)
+
+        # The IdP can interrupt the flow with a terms-and-conditions interstitial
+        # (e.g. ?updated=dataprivacy). Authentication has genuinely not completed,
+        # but "check email and password" would be misleading there (issue #15).
+        if "terms-and-conditions" in landing:
+            raise AuthError(
+                "Login interrupted: the identity provider requires accepting updated "
+                "terms and conditions for this account (try completing a login in a "
+                "browser first). See connector issue #15."
+            )
 
         # Positively confirm success: a completed flow lands back on the portal
         # host (via /services/callbacklogin). Bad credentials re-render the
@@ -318,6 +357,19 @@ class EudaApiClient:
             raise AuthError("Login failed - check email and password")
         if urlparse(landing).netloc != portal_host:
             raise AuthError(f"Login did not complete (ended at {landing})")
+
+        # Prove the session with a cheap authenticated call instead of trusting
+        # the landing page. Only 401/403 is an authentication verdict; anything
+        # else (portal hiccup, network blip) is left to the regular request
+        # path, which retries on the connector interval.
+        try:
+            probe = self._session.get(BASE_URL + VEHICLES_PATH, timeout=self._timeout)
+        except requests.RequestException as err:
+            LOG.debug("login step5: session probe network error ignored: %s", err)
+            return
+        if probe.status_code in (401, 403):
+            raise AuthError(f"Login did not establish a session (probe HTTP {probe.status_code})")
+        LOG.debug("login step5: session probe HTTP %s", probe.status_code)
 
     def _build_authorize_url(self) -> str:
         """Construct the OIDC authorize URL (bypasses the broken AEM servlet)."""

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -21,7 +21,7 @@ import requests
 
 from carconnectivity.units import Length, Speed
 
-from carconnectivity_connectors.vw_eu_data_act.client import ApiError, EudaApiClient
+from carconnectivity_connectors.vw_eu_data_act.client import ApiError, AuthError, EudaApiClient
 from carconnectivity_connectors.vw_eu_data_act.connector import (
     Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS,
     _charge_mode, _charge_mode_flat, VWEudaChargeMode,
@@ -1187,3 +1187,89 @@ def test_odometer_prefers_highest_slot(connector):
     connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
 
     assert garage.get_vehicle(VIN).odometer.value == 70908
+
+
+# --- login verdict (issue #29) ----------------------------------------------
+
+PORTAL = "https://eu-data-act.drivesomethinggreater.com"
+
+
+class _FakeResp:
+    """Minimal stand-in for requests.Response in login-verdict tests."""
+
+    def __init__(self, url, status_code=200, history=(), text=""):
+        self.url = url
+        self.status_code = status_code
+        self.history = list(history)
+        self.text = text
+
+
+def _callback_hop():
+    return _FakeResp(PORTAL + "/services/callbacklogin?state=ch__en__VOLKSWAGEN_PASSENGER_CARS&code=x",
+                     status_code=302)
+
+
+def _client_with_probe(status_code):
+    client = EudaApiClient(email="u", password="p")
+    client._session.get = lambda url, **kwargs: _FakeResp(url, status_code)
+    return client
+
+
+def test_login_missing_landing_page_is_not_a_failure():
+    """A 4xx on the localized CMS landing page after the chain passed
+    /services/callbacklogin is cosmetic (the page does not exist for e.g.
+    country "ch", issue #29): the login must be treated as successful."""
+    client = _client_with_probe(200)
+    resp = _FakeResp(PORTAL + "/ch/en/user.html", status_code=404, history=[_callback_hop()])
+    client._finish_login(resp)  # pylint: disable=protected-access
+
+
+def test_login_4xx_without_callback_still_fails():
+    """A 4xx at the end of a chain that never reached the portal callback is a
+    real login failure and must keep raising AuthError."""
+    client = _client_with_probe(200)
+    resp = _FakeResp("https://identity.vwgroup.io/signin-service/v1/x/login/authenticate",
+                     status_code=400)
+    with pytest.raises(AuthError, match="Login rejected"):
+        client._finish_login(resp)  # pylint: disable=protected-access
+
+
+def test_login_bad_credentials_still_detected():
+    """Bad credentials re-render the identity sign-in page (HTTP 200, URL still
+    on signin-service): detection must be unchanged."""
+    client = _client_with_probe(200)
+    resp = _FakeResp("https://identity.vwgroup.io/signin-service/v1/x/login/authenticate",
+                     status_code=200)
+    with pytest.raises(AuthError, match="check email and password"):
+        client._finish_login(resp)  # pylint: disable=protected-access
+
+
+def test_login_terms_interstitial_gets_specific_message():
+    """The terms-and-conditions interstitial (issue #15) is a real login stop,
+    but the generic "check email and password" message is misleading there: a
+    dedicated message must point at the terms acceptance instead."""
+    client = _client_with_probe(200)
+    resp = _FakeResp("https://identity.vwgroup.io/signin-service/v1/x/terms-and-conditions"
+                     "?relayState=y&updated=dataprivacy",
+                     status_code=200)
+    with pytest.raises(AuthError, match="terms and conditions"):
+        client._finish_login(resp)  # pylint: disable=protected-access
+
+
+def test_login_probe_rejects_sessionless_login():
+    """If the authenticated probe answers 401/403, no session was established:
+    the login must fail with a clear message instead of failing later with a
+    confusing error on the first API call."""
+    client = _client_with_probe(401)
+    resp = _FakeResp(PORTAL + "/ch/en/user.html", status_code=404, history=[_callback_hop()])
+    with pytest.raises(AuthError, match="did not establish a session"):
+        client._finish_login(resp)  # pylint: disable=protected-access
+
+
+def test_login_probe_tolerates_portal_hiccup():
+    """A probe failure other than 401/403 (e.g. HTTP 500) is not an
+    authentication verdict: the login proceeds and the regular request path
+    handles the outage on its own retry cadence."""
+    client = _client_with_probe(500)
+    resp = _FakeResp(PORTAL + "/si/sl/user.html", status_code=200, history=[_callback_hop()])
+    client._finish_login(resp)  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary

Fixes #29: for locales whose localized portal landing page does not exist (for example `country: ch`, where `/ch/en/user.html`, `/ch/fr/user.html` and `/ch/de/user.html` all return 404), a fully successful login was reported as `Login rejected (HTTP 404)`. The login verdict was derived from the HTTP status of the last page of the credentials redirect chain, which is a localized CMS page unrelated to authentication.

## Changes

- `_do_login` step 4 is factored into `_finish_login`, which tolerates a 4xx final page when the redirect chain passed the portal's `/services/callbacklogin` hop (the step that exchanges the OIDC code and sets the session cookies). A 4xx on a chain that never reached the callback still raises `AuthError` exactly as before.
- The session is then positively confirmed with a cheap authenticated probe of `/proxy_api/consent/me/vehicles` instead of trusting the landing page: 401/403 raise a clear `AuthError("Login did not establish a session")`, while other failures (portal hiccup, network blip) are logged and left to the regular request path and its retries, so a portal outage is not misreported as a credentials problem. Verified live that this endpoint answers a plain 401 without redirects when unauthenticated.
- The terms-and-conditions interstitial (see #15) now raises a dedicated message pointing at the terms acceptance instead of the misleading `Login failed - check email and password`. This does not fix #15 (the interstitial itself is not handled), it only makes the diagnostic honest.

The existing failure detections are unchanged: bad credentials (identity page re-rendered on `signin-service`), unexpected final host, and IdP 4xx without callback all keep raising the same errors.

## Validation

- 6 new offline tests in `tests/test_offline.py` covering: the cosmetic 404 after callback is accepted, a 4xx without callback still fails, bad credentials are still detected, the probe rejects a sessionless login, the probe tolerates a portal 5xx, and the terms interstitial gets its specific message.
- Full offline suite passes: 60 passed, 2 skipped.
- Portal behaviour confirmed live: `/ch/{en,fr,de}/user.html` return 404 while `/de/de/user.html` and `/si/sl/user.html` return 200, and `/content/euda/ch/en/user.html` 301-redirects to `/ch/en/user.html`, matching the redirect chain reported in #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
