### PR TITLE
fix(client): send a browser-like header set (Accept-Language) on the session

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/client.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/client.py
@@ -57,6 +57,22 @@ USER_AGENT = (
 NO_CONTENT_SUFFIX = "_no_content_found.zip"
 
 
+def _accept_language(country: str, language: str) -> str:
+    """Browser-like ``Accept-Language`` derived from the configured locale.
+
+    The identity provider resolves per-locale variants of pending legal
+    documents from this header; a header-less client can be routed to a
+    terms-and-conditions interstitial for a document variant the user was
+    never offered by any official VW surface (issue #15). Every official
+    client sends this header.
+    """
+    lang = language.lower()
+    parts = [f"{lang}-{country.upper()}", f"{lang};q=0.9"]
+    if lang != "en":
+        parts.append("en;q=0.8")
+    return ",".join(parts)
+
+
 class ApiError(Exception):
     """Generic API failure."""
 
@@ -214,7 +230,16 @@ class EudaApiClient:
                  language: str = DEFAULT_LANGUAGE, brand: str = DEFAULT_BRAND,
                  timeout: int = 60) -> None:
         self._session = requests.Session()
-        self._session.headers.update({"User-Agent": USER_AGENT})
+        # Browser-like header set: the IdP routes header-less clients to legal
+        # interstitials a browser never sees (issue #15), Accept-Language being
+        # the prime suspect. Accept keeps */* so the proxy_api JSON responses
+        # are unaffected.
+        self._session.headers.update({
+            "User-Agent": USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": _accept_language(country, language),
+            "Upgrade-Insecure-Requests": "1",
+        })
         # Retry transient connection/5xx errors at the transport layer so a single
         # dropped connection (the portal/Azure blob occasionally closes idle
         # sockets) does not bubble up as a hard failure.

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1273,3 +1273,23 @@ def test_login_probe_tolerates_portal_hiccup():
     client = _client_with_probe(500)
     resp = _FakeResp(PORTAL + "/si/sl/user.html", status_code=200, history=[_callback_hop()])
     client._finish_login(resp)  # pylint: disable=protected-access
+
+
+# --- session headers (issue #15) ---------------------------------------------
+
+def test_session_sends_locale_headers():
+    """The session must send a browser-like header set: the IdP routes
+    header-less clients to legal interstitials a browser never sees (issue
+    #15). Accept-Language follows the configured country/language."""
+    client = EudaApiClient(email="u", password="p", country="ch", language="fr")
+    assert client._session.headers["Accept-Language"] == "fr-CH,fr;q=0.9,en;q=0.8"
+    assert "text/html" in client._session.headers["Accept"]
+    assert "*/*" in client._session.headers["Accept"]
+
+
+def test_session_accept_language_default_and_english():
+    """Default locale (si/sl) and an English locale (no duplicate 'en' tail)."""
+    default = EudaApiClient(email="u", password="p")
+    assert default._session.headers["Accept-Language"] == "sl-SI,sl;q=0.9,en;q=0.8"
+    english = EudaApiClient(email="u", password="p", country="ie", language="en")
+    assert english._session.headers["Accept-Language"] == "en-IE,en;q=0.9"


### PR DESCRIPTION
## Summary

First half of the follow-up to #15. The 4-variant diagnostic matrix posted there showed the IdP routes clients to the `terms-and-conditions?updated=dataprivacy` interstitial depending on the request headers (TLS fingerprint and form fields were ruled out), with `Accept-Language` as the prime suspect: pending legal documents are versioned per locale, so a header-less client can be asked to accept a document variant the user was never offered by any official VW surface.

## Changes

- New `_accept_language(country, language)` helper builds a browser-like `Accept-Language` from the configured locale (e.g. `fr-CH,fr;q=0.9,en;q=0.8`), matching what every official client sends.
- The session now sends `Accept-Language`, a browser `Accept` (keeping `*/*` so the `proxy_api` JSON responses are unaffected) and `Upgrade-Insecure-Requests` next to the existing `User-Agent`. The seatcupra connector sends the same header family on its sessions.

## Validation

- 2 new offline tests covering the locale-derived header (including the default `si`/`sl` locale and the no-duplicate English case) and the `Accept` value.
- Full offline suite passes: 62 passed, 2 skipped.

Companion PR: the opt-in acceptance of the interstitial itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
