### PR TITLE
feat(client): opt-in acceptance of the terms-and-conditions interstitial (accept_terms_on_login)

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/client.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/client.py
@@ -212,7 +212,7 @@ class EudaApiClient:
 
     def __init__(self, email: str, password: str, *, country: str = DEFAULT_COUNTRY,
                  language: str = DEFAULT_LANGUAGE, brand: str = DEFAULT_BRAND,
-                 timeout: int = 60) -> None:
+                 timeout: int = 60, accept_terms_on_login: bool = False) -> None:
         self._session = requests.Session()
         self._session.headers.update({"User-Agent": USER_AGENT})
         # Retry transient connection/5xx errors at the transport layer so a single
@@ -234,6 +234,7 @@ class EudaApiClient:
         self._state = f"{country}__{language}__{resolved.key}"
         self._client_id = resolved.client_id
         self._timeout = timeout
+        self._accept_terms_on_login = accept_terms_on_login
         self._logged_in = False
 
     def close(self) -> None:
@@ -319,7 +320,7 @@ class EudaApiClient:
         )
         self._finish_login(resp)
 
-    def _finish_login(self, resp: requests.Response) -> None:
+    def _finish_login(self, resp: requests.Response, _terms_retried: bool = False) -> None:
         """Judge the end of the credentials redirect chain and confirm the session.
 
         The chain ends on a localized CMS landing page whose availability is
@@ -342,11 +343,19 @@ class EudaApiClient:
         # The IdP can interrupt the flow with a terms-and-conditions interstitial
         # (e.g. ?updated=dataprivacy). Authentication has genuinely not completed,
         # but "check email and password" would be misleading there (issue #15).
+        # With accept_terms_on_login enabled, POST the acceptance embedded in the
+        # page and resume the flow (once: a second interstitial means the
+        # acceptance was not recorded and retrying would loop).
         if "terms-and-conditions" in landing:
+            if self._accept_terms_on_login and not _terms_retried:
+                LOG.info("Login interrupted by a terms-and-conditions update; "
+                         "accepting it (accept_terms_on_login is enabled)")
+                self._finish_login(self._accept_terms(landing, landing_html), _terms_retried=True)
+                return
             raise AuthError(
                 "Login interrupted: the identity provider requires accepting updated "
                 "terms and conditions for this account (try completing a login in a "
-                "browser first). See connector issue #15."
+                "browser first, or set accept_terms_on_login). See connector issue #15."
             )
 
         # Positively confirm success: a completed flow lands back on the portal
@@ -370,6 +379,43 @@ class EudaApiClient:
         if probe.status_code in (401, 403):
             raise AuthError(f"Login did not establish a session (probe HTTP {probe.status_code})")
         LOG.debug("login step5: session probe HTTP %s", probe.status_code)
+
+    def _accept_terms(self, url: str, html: str) -> requests.Response:
+        """POST the acceptance form of a terms-and-conditions interstitial.
+
+        The page embeds a genuine acceptance form in its JS ``templateModel``
+        (issue #15): ``relayState``/``hmac``, ``countryOfResidence`` (sent
+        upper-cased) and the pending document flattened into
+        ``legalDocuments[0].<key>`` fields with booleans as ``yes``/``no``
+        (link/version/summary keys are not part of the form). Same scheme as
+        the seatcupra connector and WeConnect-python's acceptTermsOnLogin.
+        The IdP records the acceptance account-side and resumes the OIDC flow.
+        """
+        model = _extract_template_model(html)
+        fields: Dict[str, str] = {}
+        for key in ("relayState", "hmac"):
+            if model.get(key):
+                fields[key] = model[key]
+        country = model.get("countryOfResidence")
+        if country:
+            fields["countryOfResidence"] = str(country).upper()
+        documents = model.get("legalDocuments") or []
+        document = documents[0] if documents else {}
+        for key, value in document.items():
+            if key in ("skipLink", "declineLink", "majorVersion", "minorVersion", "changeSummary"):
+                continue
+            fields[f"legalDocuments[0].{key}"] = ("yes" if value else "no") if isinstance(value, bool) else value
+        csrf = _extract_csrf(html)
+        if csrf:
+            fields["_csrf"] = csrf
+        # The form target is the templateModel's loginUrl when present; fall
+        # back to the page URL stripped of its query (both observed working).
+        action = urljoin(url, model["loginUrl"]) if model.get("loginUrl") else url.split("?", 1)[0]
+        LOG.info("login terms: accepting document %s v%s.%s",
+                 document.get("name") or document.get("textId") or "?",
+                 document.get("majorVersion", "?"), document.get("minorVersion", "?"))
+        LOG.debug("login terms: POST acceptance to %s fields=%s", action, sorted(fields))
+        return self._session.post(action, data=fields, headers={"Referer": url}, timeout=self._timeout)
 
     def _build_authorize_url(self) -> str:
         """Construct the OIDC authorize URL (bypasses the broken AEM servlet)."""

--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -478,6 +478,11 @@ class Connector(BaseConnector):
         self.active_config['language'] = config.get('language', DEFAULT_LANGUAGE)
         self.active_config['brand'] = config.get('brand', DEFAULT_BRAND)
 
+        # Opt-in: accept a pending terms-and-conditions/data-privacy document
+        # during login instead of failing (issue #15). Off by default because it
+        # accepts a legal document on the user's behalf.
+        self.active_config['accept_terms_on_login'] = bool(config.get('accept_terms_on_login', False))
+
         # --- hidden VINs ---
         if 'hide_vins' in config and config['hide_vins'] is not None:
             self.active_config['hide_vins'] = config['hide_vins']
@@ -504,7 +509,8 @@ class Connector(BaseConnector):
         self.client: EudaApiClient = EudaApiClient(
             email=self.active_config['username'], password=self.active_config['password'],
             country=self.active_config['country'], language=self.active_config['language'],
-            brand=self.active_config['brand'])
+            brand=self.active_config['brand'],
+            accept_terms_on_login=self.active_config['accept_terms_on_login'])
 
     # -- lifecycle ---------------------------------------------------------
 

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1273,3 +1273,82 @@ def test_login_probe_tolerates_portal_hiccup():
     client = _client_with_probe(500)
     resp = _FakeResp(PORTAL + "/si/sl/user.html", status_code=200, history=[_callback_hop()])
     client._finish_login(resp)  # pylint: disable=protected-access
+
+
+# --- terms-and-conditions auto-acceptance (issue #15) ------------------------
+
+TERMS_URL = ("https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/"
+             "terms-and-conditions?relayState=rs1&updated=dataprivacy")
+
+# Shape observed in issue #15: the acceptance form lives in the JS
+# templateModel, with the pending document under legalDocuments[0].
+TERMS_HTML = """
+<script>
+window._IDK = {
+  templateModel: {"relayState": "rs1", "hmac": "h1", "countryOfResidence": "ch",
+    "loginUrl": "/signin-service/v1/xxx@apps_vw-dilab_com/terms-and-conditions",
+    "legalDocuments": [{"name": "dataPrivacy", "textId": "t16",
+      "majorVersion": 16, "minorVersion": 1,
+      "skippable": false, "declinable": true, "saveLink": "/save",
+      "skipLink": "/skip", "declineLink": "/decline", "changeSummary": "upd"}]},
+  csrf_token: 'tok123'
+};
+</script>
+"""
+
+
+def _terms_client(accept, post_result):
+    """Client whose POSTs are captured and whose GET probe answers 200."""
+    client = EudaApiClient(email="u", password="p", accept_terms_on_login=accept)
+    calls = []
+
+    def _post(url, data=None, **kwargs):
+        calls.append((url, data))
+        return post_result
+
+    client._session.post = _post
+    client._session.get = lambda url, **kwargs: _FakeResp(url, 200)
+    return client, calls
+
+
+def test_terms_interstitial_accepted_when_opted_in():
+    """With accept_terms_on_login, the acceptance form embedded in the
+    interstitial's templateModel is POSTed (issue #15 recipe: countryOfResidence
+    upper-cased, legalDocuments[0].* flattened with yes/no booleans, link and
+    version keys excluded, _csrf from csrf_token) and the login completes."""
+    success = _FakeResp(PORTAL + "/si/sl/user.html", status_code=200, history=[_callback_hop()])
+    client, calls = _terms_client(True, success)
+    client._finish_login(_FakeResp(TERMS_URL, status_code=200, text=TERMS_HTML))  # pylint: disable=protected-access
+
+    assert len(calls) == 1
+    url, data = calls[0]
+    assert url == "https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/terms-and-conditions"
+    assert data["relayState"] == "rs1"
+    assert data["hmac"] == "h1"
+    assert data["_csrf"] == "tok123"
+    assert data["countryOfResidence"] == "CH"
+    assert data["legalDocuments[0].skippable"] == "no"
+    assert data["legalDocuments[0].declinable"] == "yes"
+    assert data["legalDocuments[0].saveLink"] == "/save"
+    assert data["legalDocuments[0].name"] == "dataPrivacy"
+    for excluded in ("majorVersion", "minorVersion", "skipLink", "declineLink", "changeSummary"):
+        assert f"legalDocuments[0].{excluded}" not in data
+
+
+def test_terms_interstitial_still_raises_without_opt_in():
+    """Without the opt-in, the interstitial keeps raising the dedicated
+    AuthError and nothing is POSTed on the user's behalf."""
+    client, calls = _terms_client(False, None)
+    with pytest.raises(AuthError, match="terms and conditions"):
+        client._finish_login(_FakeResp(TERMS_URL, status_code=200, text=TERMS_HTML))  # pylint: disable=protected-access
+    assert not calls
+
+
+def test_terms_acceptance_does_not_loop():
+    """If the IdP serves the interstitial again after the acceptance POST, the
+    login fails instead of retrying forever."""
+    still_terms = _FakeResp(TERMS_URL, status_code=200, text=TERMS_HTML)
+    client, calls = _terms_client(True, still_terms)
+    with pytest.raises(AuthError, match="terms and conditions"):
+        client._finish_login(_FakeResp(TERMS_URL, status_code=200, text=TERMS_HTML))  # pylint: disable=protected-access
+    assert len(calls) == 1

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1275,7 +1275,6 @@ def test_login_probe_tolerates_portal_hiccup():
     client._finish_login(resp)  # pylint: disable=protected-access
 
 
-<<<<<<< HEAD
 # --- terms-and-conditions auto-acceptance (issue #15) ------------------------
 
 TERMS_URL = ("https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/"


### PR DESCRIPTION
## Summary

Second half of the follow-up to #15: opt-in handling of the `terms-and-conditions` interstitial. As diagnosed there, the IdP can hold a pending legal document (e.g. an updated data-privacy statement) that no official VW surface ever offers the user to accept; the interstitial page embeds a genuine acceptance form in its JS `templateModel`, and posting it records the acceptance account-side, after which the stock login flow passes.

## Changes

- New connector config option `accept_terms_on_login` (default `false`, since it accepts a legal document on the user's behalf), passed through to the client.
- When enabled and the credentials redirect chain lands on a `terms-and-conditions` page, `_accept_terms()` POSTs the acceptance form and the login resumes: `relayState`/`hmac`, `countryOfResidence` upper-cased, `legalDocuments[0].*` flattened with booleans as `yes`/`no` (link/version/summary keys excluded), `_csrf` from `csrf_token`, target taken from the `templateModel` `loginUrl` (fallback: the page URL without its query). This is the exact recipe validated in #15 and the same scheme as the seatcupra connector and WeConnect-python's `acceptTermsOnLogin`.
- A second interstitial right after the acceptance fails with the dedicated error instead of looping, and the error message without the opt-in now mentions the option.

## Dependencies

None; independent of the companion `Accept-Language` header PR (which prevents the IdP from resolving a document variant the user could never accept in the first place). Both are worth having: the header fix is preventive, this one is the cure when a document is genuinely pending.

## Validation

- 3 new offline tests against a synthetic interstitial matching the `templateModel` shape documented in #15: acceptance form posted correctly when opted in (field-by-field assertions), dedicated error and no POST without the opt-in, no retry loop when the IdP serves the interstitial again.
- Full offline suite passes: 63 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
