### PR TITLE
feat(dataset): map datapoints identified by their portal key only (fixes #33)

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -153,6 +153,10 @@ KNOWN_MAPPED_FIELDS: set[str] = {
     'mileage.value',
     'mileage.unit',
     'mileage.state',
+    # Bare leaves carrying no meaning in their name: handled by key instead
+    # (see KEY_PRIMARY_RANGE below), so they must not be reported as unmapped.
+    'value',
+    'unit',
     'locked',
     'window_heating_state',
     'battery_state_report.soc',
@@ -232,6 +236,17 @@ KNOWN_MAPPED_FIELDS: set[str] = {
 KNOWN_MAPPED_PREFIXES: "Tuple[str, ...]" = (
     'energy_contents.maximal_energy_content',
 )
+
+# --- datapoints identified by their portal key only ------------------------
+# A handful of datapoints reach the flat export with a semantically empty
+# ``dataFieldName`` (a bare ``value`` / ``unit``), so the name cannot be mapped;
+# the official data dictionary identifies them by key instead. Those keys are
+# name-based UUIDs (version 3), i.e. a deterministic hash of the field identity,
+# and are therefore stable across vehicles. Descriptions below are quoted from
+# the dictionary. Reported by users whose vehicle sends no named range field
+# (upstream issues #12 and #33).
+KEY_PRIMARY_RANGE = '0ca40e18-0564-3eda-bcc0-7aee9ef44f04'       # "Value of the primary range"
+KEY_PRIMARY_RANGE_UNIT = '8d508462-17e7-3027-8980-cbbbc86d9496'  # "Unit of the value; type DistanceUnit"
 
 # Portal door id -> (open_state field, locked_state field). Note the double
 # underscore in the rear-left lock field (portal quirk).
@@ -985,8 +1000,21 @@ class Connector(BaseConnector):
             # it is reported as the primary engine.
             e_range = dataset.value_of('cruising_range_secondary_engine') if is_phev \
                 else dataset.value_of('cruising_range_primary_engine')
+            e_range_unit = Length.KM
+            if e_range is None and not isinstance(vehicle, CombustionVehicle):
+                # Some vehicles deliver no named range field at all: the range
+                # arrives as a bare 'value' datapoint that only its key
+                # identifies (issue #33). That key holds the *primary* range,
+                # which on anything with a combustion engine is the fuel one,
+                # so it is only trusted for a pure EV. Testing the promoted
+                # vehicle class rather than this dataset's is_phev matters: a
+                # hybrid whose snapshot happens to carry no fuel field would
+                # otherwise have its fuel range published as electric range.
+                e_range = dataset.value_by_key(KEY_PRIMARY_RANGE)
+                if resolve_distance_unit(dataset.value_by_key(KEY_PRIMARY_RANGE_UNIT)) == 'mi':
+                    e_range_unit = Length.MI
             if e_range is not None:
-                drive.range._set_value(value=e_range, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
+                drive.range._set_value(value=e_range, measured=captured_at, unit=e_range_unit)  # pylint: disable=protected-access
                 drive.range.precision = 1
 
             # Some flat-format datasets only provide a bare 'mileage' field.

--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -330,6 +330,23 @@ class Dataset:
         dp = self.by_field(field_name)
         return dp.value if dp is not None else None
 
+    def by_key(self, key: str) -> Optional[DataPoint]:
+        """Return the data point carrying a specific portal key (UUID).
+
+        A few datapoints reach the flat export with a semantically empty
+        ``dataFieldName`` (a bare ``value`` / ``unit``); only their key tells
+        them apart, and the official data dictionary is indexed by that key.
+        Keys are stable across vehicles: the vast majority are name-based
+        UUIDs (version 3), i.e. a deterministic hash of the field identity
+        rather than a per-vehicle or per-report identifier.
+        """
+        return self.points.get(key)
+
+    def value_by_key(self, key: str):
+        """Return the typed value of the point with ``key`` or ``None``."""
+        dp = self.by_key(key)
+        return dp.value if dp is not None else None
+
     def freshest_numeric_by_prefix(self, prefix: str):
         """Return a numeric value among fields whose name starts with ``prefix``.
 

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -25,6 +25,7 @@ from carconnectivity_connectors.vw_eu_data_act.client import ApiError, AuthError
 from carconnectivity_connectors.vw_eu_data_act.connector import (
     Connector, _filename_timestamp, KNOWN_MAPPED_FIELDS,
     _charge_mode, _charge_mode_flat, VWEudaChargeMode,
+    KEY_PRIMARY_RANGE, KEY_PRIMARY_RANGE_UNIT,
 )
 from carconnectivity_connectors.vw_eu_data_act.dataset import Dataset
 from carconnectivity_connectors.vw_eu_data_act.vehicle import VWEudaElectricVehicle, VWEudaVehicle
@@ -1273,3 +1274,104 @@ def test_login_probe_tolerates_portal_hiccup():
     client = _client_with_probe(500)
     resp = _FakeResp(PORTAL + "/si/sl/user.html", status_code=200, history=[_callback_hop()])
     client._finish_login(resp)  # pylint: disable=protected-access
+
+
+# --- datapoints identified by key only (issues #12 / #33) --------------------
+
+def test_dataset_lookup_by_key():
+    """Datapoints whose dataFieldName carries no meaning must be reachable by
+    their portal key."""
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": KEY_PRIMARY_RANGE, "dataFieldName": "value", "value": "386"},
+        {"key": "57b433c8-3dcc-3fbf-9b38-74f8f6480682", "dataFieldName": "value", "value": "7"},
+    ]})
+
+    assert ds.value_by_key(KEY_PRIMARY_RANGE) == 386
+    assert ds.by_key(KEY_PRIMARY_RANGE).field_name == "value"
+    assert ds.value_by_key("no-such-key") is None
+
+
+def test_range_by_key_when_no_named_field(connector):
+    """An ID.4 reporting no cruising_range_* field at all delivers the range as
+    a bare 'value' datapoint identified only by its key (issue #33): it must
+    still reach drive.range."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "80"},
+        {"key": KEY_PRIMARY_RANGE, "dataFieldName": "value", "value": "386"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    drive = garage.get_vehicle(VIN).get_electric_drive()
+    assert drive.range.value == 386
+    assert drive.range.unit == Length.KM
+
+
+def test_range_by_key_honours_companion_unit(connector):
+    """The bare range has a companion 'unit' datapoint, also key-identified."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "80"},
+        {"key": KEY_PRIMARY_RANGE, "dataFieldName": "value", "value": "240"},
+        {"key": KEY_PRIMARY_RANGE_UNIT, "dataFieldName": "unit", "value": "MILES"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).get_electric_drive().range.unit == Length.MI
+
+
+def test_named_range_field_wins_over_key(connector):
+    """The by-key lookup is a fallback: a vehicle sending the named field keeps
+    using it."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    ds = Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "80"},
+        {"key": "55e0d40b-38ed-3cb5-9dcd-6193df6fc493",
+         "dataFieldName": "cruising_range_primary_engine", "value": "300"},
+        {"key": KEY_PRIMARY_RANGE, "dataFieldName": "value", "value": "999"},
+    ]})
+    connector._map_dataset(VIN, ds)  # pylint: disable=protected-access
+
+    assert garage.get_vehicle(VIN).get_electric_drive().range.value == 300
+
+
+def test_range_key_ignored_on_phev(connector):
+    """The key holds the *primary* range, which is the combustion one as soon
+    as there is an engine: it must never be pushed onto the electric drive of a
+    hybrid, including on a snapshot that carries no fuel field of its own."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaElectricVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    # First snapshot establishes the hybrid drivetrain (electric + fuel).
+    connector._map_dataset(VIN, Dataset.from_json({"vin": VIN, "Data": [  # pylint: disable=protected-access
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "80"},
+        {"key": "f1000000-0000-0000-0000-000000000001",
+         "dataFieldName": "fuel_level_current_level", "value": "33"},
+    ]}))
+
+    # A later snapshot without any named range must NOT publish the primary
+    # (fuel) range as the electric one.
+    connector._map_dataset(VIN, Dataset.from_json({"vin": VIN, "Data": [  # pylint: disable=protected-access
+        {"key": "ae0294b4-1286-3e98-a818-1485b8d88430", "dataFieldName": "state_of_charge",
+         "value": "80"},
+        {"key": KEY_PRIMARY_RANGE, "dataFieldName": "value", "value": "999"},
+    ]}))
+
+    assert garage.get_vehicle(VIN).get_electric_drive().range.value is None
+
+
+def test_bare_value_not_reported_as_unmapped():
+    """Bare 'value'/'unit' leaves are handled by key, so they must not show up
+    in the unmapped-sensor diagnostics."""
+    assert 'value' in KNOWN_MAPPED_FIELDS
+    assert 'unit' in KNOWN_MAPPED_FIELDS


### PR DESCRIPTION
## Summary

Some vehicles deliver no named range field at all: no `range`, no `cruising_range_primary_engine`, no `cruising_range_combined`. The range still reaches the export, but as a bare entry whose `dataFieldName` is just `value`, so only the portal key identifies it. Reported for an ID.4 in #33, and the same shape as the by-key lookup requested in #12.

The official data dictionary is indexed by key and documents:

- `0ca40e18-0564-3eda-bcc0-7aee9ef44f04` = "Value of the primary range"
- `8d508462-17e7-3027-8980-cbbbc86d9496` = "Unit of the value; type DistanceUnit"

Keys are safe to rely on: the vast majority of dictionary entries are name-based UUIDs (version 3), i.e. a deterministic hash of the field identity rather than a per-vehicle or per-report identifier. Confirmed empirically as well, the `message_id` entries of the reporter's ID.4 carry the very same UUIDs as this repository's sample dataset from a different vehicle, while holding different values.

## Changes

- `Dataset.by_key()` / `Dataset.value_by_key()`: lookup by portal key (the points are already indexed by key, so this is a plain dict access).
- The range key is used as a **fallback behind the named `cruising_range_*` fields**, so vehicles that report the named field are untouched.
- The companion unit datapoint is honoured instead of assuming kilometres, exactly like the existing `mileage.unit` handling.
- The fallback is restricted to pure EVs, because that key holds the *primary* range, which is the combustion one as soon as the car has an engine. The guard tests the promoted vehicle class rather than the current snapshot: an export only refreshes what diverged, so a hybrid snapshot can legitimately carry no fuel field at all, and testing the snapshot would publish the fuel range as the electric one. This case is covered by a regression test.
- Bare `value` / `unit` are added to the known fields so they no longer show up in the unmapped-sensor diagnostics.

## Validation

- 6 new offline tests: key lookup, the reported ID.4 shape, the miles companion unit, precedence of the named field, the hybrid regression described above, and the diagnostics.
- Full offline suite passes: 71 passed, 2 skipped.

Refs #12. The reporter of #33 has confirmed the key on a fresh export and offered to test the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
