### PR TITLE
fix(maintenance): keep the countdown sign on service distances

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -929,10 +929,15 @@ class Connector(BaseConnector):
             vehicle.window_heatings.heating_state._set_value(  # pylint: disable=protected-access
                 WINDOW_HEATING_MAPPING.get(wh, WindowHeatings.HeatingState.UNKNOWN), measured=captured_at)
 
-        # Maintenance intervals. The portal encodes a signed countdown: a negative
-        # value is the amount still remaining, zero is due, a positive value is
-        # overdue. Expose the time interval as a concrete due date (which conveys
-        # overdue naturally as a past date) and the distance as remaining km.
+        # Maintenance intervals. The portal encodes a signed countdown rising
+        # toward zero: a negative value is the amount still remaining, zero is
+        # due, a positive value is overdue. Expose the time interval as a
+        # concrete due date (which conveys overdue naturally as a past date) and
+        # the distance as remaining km, negating rather than taking the absolute
+        # value: abs() would render "overdue by 500 km" as "500 km remaining",
+        # collapsing the two opposite states onto the same reading. Negation
+        # keeps them apart (remaining stays positive, overdue goes negative) and
+        # matches how the due dates above already handle the sign.
         # The bootstrap-merged dataset can lack a capture time, so anchor the due
         # date on "now" when captured_at is absent.
         date_anchor = captured_at or datetime.now(tz=timezone.utc)
@@ -947,11 +952,11 @@ class Connector(BaseConnector):
         insp_dist = dataset.value_of('maintenance_interval_distance_until_inspection')
         if insp_dist is not None:
             vehicle.maintenance.inspection_due_after._set_value(  # pylint: disable=protected-access
-                value=abs(insp_dist), measured=captured_at, unit=Length.KM)
+                value=-insp_dist, measured=captured_at, unit=Length.KM)
         oil_dist = dataset.value_of('maintenance_interval_distance_until_oil_change')
         if oil_dist is not None:
             vehicle.maintenance.oil_service_due_after._set_value(  # pylint: disable=protected-access
-                value=abs(oil_dist), measured=captured_at, unit=Length.KM)
+                value=-oil_dist, measured=captured_at, unit=Length.KM)
 
         # Outside (ambient) temperature, reported in deci-Kelvin.
         outside = decikelvin_to_celsius(dataset.value_of('outside_temperature'))

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1474,3 +1474,53 @@ def test_session_accept_language_default_and_english():
     assert default._session.headers["Accept-Language"] == "sl-SI,sl;q=0.9,en;q=0.8"
     english = EudaApiClient(email="u", password="p", country="ie", language="en")
     assert english._session.headers["Accept-Language"] == "en-IE,en;q=0.9"
+
+
+# --- maintenance countdown sign ----------------------------------------------
+
+def _maintenance_dataset(insp_dist, oil_dist):
+    return Dataset.from_json({"vin": VIN, "Data": [
+        {"key": "m1", "dataFieldName": "maintenance_interval_distance_until_inspection",
+         "value": str(insp_dist)},
+        {"key": "m2", "dataFieldName": "maintenance_interval_distance_until_oil_change",
+         "value": str(oil_dist)},
+    ]})
+
+
+def test_maintenance_distance_remaining_is_positive(connector):
+    """The portal counts down toward zero, so a negative reading means "still
+    remaining" and must surface as a positive distance."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    connector._map_dataset(VIN, _maintenance_dataset(-23500, -12000))  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.maintenance.inspection_due_after.value == 23500
+    assert v.maintenance.oil_service_due_after.value == 12000
+
+
+def test_maintenance_distance_overdue_stays_negative(connector):
+    """A positive portal reading means the service is overdue. Taking the
+    absolute value would render "overdue by 500 km" exactly like "500 km
+    remaining"; negating keeps the two states apart."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    connector._map_dataset(VIN, _maintenance_dataset(500, 1200))  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.maintenance.inspection_due_after.value == -500
+    assert v.maintenance.oil_service_due_after.value == -1200
+
+
+def test_maintenance_distance_due_now_is_zero(connector):
+    """Zero is the due point and must stay zero."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    connector._map_dataset(VIN, _maintenance_dataset(0, 0))  # pylint: disable=protected-access
+
+    v = garage.get_vehicle(VIN)
+    assert v.maintenance.inspection_due_after.value == 0
+    assert v.maintenance.oil_service_due_after.value == 0


### PR DESCRIPTION
## Summary

The portal encodes maintenance intervals as a signed countdown rising toward zero: a negative value is the amount still remaining, zero is due, a positive value is overdue. This is visible on real datasets, where the distances climb `-23500` → `-23400` → `-22400` km and the days `-130` → `-92` as the car is driven.

The due **dates** already honoured that sign, since `timedelta(days=-value)` turns an overdue interval into a past date. The **distances** did not: they went through `abs()`, which renders "overdue by 500 km" exactly like "500 km remaining". The two opposite states collapsed onto the same reading, and the one that matters most, an overdue service, was the one being hidden.

## Changes

- `inspection_due_after` and `oil_service_due_after` are negated rather than passed through `abs()`, so remaining stays positive and overdue goes negative, consistent with how the due dates already behave.
- Comment updated to spell out the encoding and why negation is the correct transform.

`RangeAttribute` sets no `minimum` on either attribute in carconnectivity, so a negative value is representable.

## Consistency with the other connectors

Checked against the reference implementation: the seatcupra connector passes `inspectionDueKm` / `oilServiceDueKm` straight to these same attributes, with no `abs()` and no negation, because its API already reports the natural convention where a positive value is the distance remaining. The inverted encoding is specific to the EU Data Act portal, which is why no equivalent fix exists in the other connectors.

That makes negation a normalisation rather than an arbitrary choice: it produces values in the very convention the reference connector feeds those attributes. Values being passed through unbounded there also confirms that negative readings are expected downstream, consistent with `RangeAttribute` carrying no `minimum`.

## Validation

- The pre-existing assertion on a remaining interval is untouched and still passes: negating a negative reading yields the same positive distance `abs()` produced.
- 3 new offline tests covering the three states of the countdown: remaining, overdue, and exactly due.
- Full offline suite: 74 passed, 2 skipped.

Same encoding, and the same fix, as in the Home Assistant integration this connector was ported from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
