### PR TITLE
feat(range): reconstruct the combined range from the per-engine ranges

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/connector.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/connector.py
@@ -1032,9 +1032,18 @@ class Connector(BaseConnector):
         if isinstance(vehicle, CombustionVehicle):
             self._map_combustion(vehicle, dataset, captured_at)
 
-        # Combined (total) range across all drives, when the portal reports it
-        # directly (the seatcupra connector instead sums the per-engine ranges).
+        # Combined (total) range across all drives. The portal often ships the
+        # cruising_range_combined slot with no value at all (observed empty on
+        # every dataset of a PHEV that reports both per-engine ranges), which
+        # left total_range permanently unset. Fall back to summing the per-engine
+        # ranges, the way the seatcupra connector builds its total. A value
+        # actually reported by the portal always wins over the computed sum.
         combined = dataset.value_of('cruising_range_combined')
+        if combined is None:
+            components = [dataset.value_of(name) for name in
+                          ('cruising_range_primary_engine', 'cruising_range_secondary_engine')]
+            usable = [c for c in components if isinstance(c, (int, float)) and not isinstance(c, bool)]
+            combined = sum(usable) if usable else None
         if combined is not None:
             vehicle.drives.total_range._set_value(value=combined, measured=captured_at, unit=Length.KM)  # pylint: disable=protected-access
             vehicle.drives.total_range.precision = 1

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1474,3 +1474,63 @@ def test_session_accept_language_default_and_english():
     assert default._session.headers["Accept-Language"] == "sl-SI,sl;q=0.9,en;q=0.8"
     english = EudaApiClient(email="u", password="p", country="ie", language="en")
     assert english._session.headers["Accept-Language"] == "en-IE,en;q=0.9"
+
+
+# --- combined range reconstruction -------------------------------------------
+
+def _range_dataset(entries):
+    return Dataset.from_json({"vin": VIN, "Data": [
+        {"key": f"r{i}", "dataFieldName": name, "value": value}
+        for i, (name, value) in enumerate(entries)
+    ]})
+
+
+def test_combined_range_reconstructed_from_engines(connector):
+    """A PHEV reporting both per-engine ranges but an empty combined slot must
+    still get a total range, summed from the components."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    connector._map_dataset(VIN, _range_dataset([  # pylint: disable=protected-access
+        ("cruising_range_primary_engine", "630"),
+        ("cruising_range_secondary_engine", "51"),
+        ("cruising_range_combined", ""),
+        ("fuel_level_current_level", "100"),
+        ("state_of_charge", "88"),
+    ]))
+
+    assert garage.get_vehicle(VIN).drives.total_range.value == 681
+
+
+def test_portal_combined_range_wins_over_sum(connector):
+    """A value actually reported by the portal takes precedence over the sum."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+
+    connector._map_dataset(VIN, _range_dataset([  # pylint: disable=protected-access
+        ("cruising_range_primary_engine", "630"),
+        ("cruising_range_secondary_engine", "51"),
+        ("cruising_range_combined", "700"),
+        ("fuel_level_current_level", "100"),
+        ("state_of_charge", "88"),
+    ]))
+
+    assert garage.get_vehicle(VIN).drives.total_range.value == 700
+
+
+def test_combined_range_single_engine(connector):
+    """With a single per-engine range the total equals it, and a dataset with
+    no per-engine range at all leaves the total unset."""
+    garage = connector.car_connectivity.garage
+    garage.add_vehicle(VIN, VWEudaVehicle(vin=VIN, garage=garage, managing_connector=connector))
+    connector._map_dataset(VIN, _range_dataset([  # pylint: disable=protected-access
+        ("cruising_range_primary_engine", "420"),
+    ]))
+    assert garage.get_vehicle(VIN).drives.total_range.value == 420
+
+    other = "WVWZZZE1ZLP000999"
+    garage.add_vehicle(other, VWEudaVehicle(vin=other, garage=garage, managing_connector=connector))
+    connector._map_dataset(other, Dataset.from_json({"vin": other, "Data": [  # pylint: disable=protected-access
+        {"key": "x1", "dataFieldName": "mileage.value", "value": "1000"},
+    ]}))
+    assert garage.get_vehicle(other).drives.total_range.value is None


### PR DESCRIPTION
## Summary

Some vehicles ship the `cruising_range_combined` slot with no value while still reporting both per-engine ranges. Observed on **every single dataset** of a PHEV across five weeks of exports: the field is present but always empty, so `drives.total_range` stayed permanently unset even though the components were right there, for instance 630 km of fuel range alongside 51 km of electric range.

## Changes

- When the portal reports no combined value, the total range is reconstructed by summing `cruising_range_primary_engine` and `cruising_range_secondary_engine`.
- A value actually reported by the portal always takes precedence over the computed sum.
- A dataset carrying no per-engine range at all still leaves the total unset, rather than publishing a spurious zero.

## Consistency with the other connectors

This is how the reference implementation already behaves: the seatcupra connector accumulates `total_range` by adding each engine's `rangeKm` as it maps the drives, and never expects a ready-made combined value from its API. The existing comment in this file already noted that difference; this change removes it, so a vehicle whose portal leaves the combined slot empty now gets the same total the other connectors would produce.

## Validation

- 3 new offline tests: reconstruction from both engines, precedence of a portal-reported value, and the single-engine plus no-range cases.
- Full offline suite: 74 passed, 2 skipped.

Ported from the equivalent change in the Home Assistant integration this connector originates from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
