### PR TITLE
fix(dataset): derive captured_at from per-field timestamps on flat format

### DIFF
--- a/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
+++ b/src/carconnectivity_connectors/vw_eu_data_act/dataset.py
@@ -279,6 +279,14 @@ class Dataset:
                 ts = parse_timestamp(dp.raw_value)
                 if ts:
                     captured.append(ts)
+        if not captured:
+            # Flat-format datasets name no car_captured_time field; their
+            # per-entry timestampUtc ("when the car last reported this field")
+            # carries the measurement side instead. Take the newest so mapping
+            # stamps values with a measurement time rather than falling back to
+            # the delivery slot time (README dataset-semantics notes; #38
+            # follow-up).
+            captured = [dp.timestamp for dp in points.values() if dp.timestamp is not None]
         return cls(
             vin=payload.get("vin", ""),
             user_id=payload.get("user_id"),

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1721,8 +1721,7 @@ def test_flat_export_premise_per_field_timestamps():
     assert len(stamps) == 4
 
     ds = Dataset.from_json(payload)
-    # Nothing is named car_captured_time on this format, so today the dataset
-    # yields no captured_at and mapping falls back to the delivery time. The
-    # 0.3.1 series derives it from the per-field timestamps instead; this
-    # assertion is the one to flip when that lands.
-    assert ds.captured_at is None
+    # Nothing is named car_captured_time on this format: captured_at is derived
+    # from the newest per-field timestampUtc, so values are stamped with a
+    # measurement time instead of the delivery slot time.
+    assert ds.captured_at == datetime(2026, 7, 31, 10, 40, 28, tzinfo=timezone.utc)


### PR DESCRIPTION
Flat-format datasets carry no `car_captured_time` field, so `captured_at` stayed empty and every attribute was stamped with the delivery slot time, which can run hours or days behind the actual measurement on a car that reports on events and goes quiet when parked. The per-entry `timestampUtc` is the measurement side of this format (see the README dataset-semantics notes merged in #40): take the newest as `captured_at` so MQTT consumers see a real measurement time.

Dotted-format behaviour is unchanged: `car_captured_time` still wins when present, and the premise-lock test on the flat fixture flips from documenting the gap to asserting the derived time. Suite: 87 passed, 2 pre-existing skips.

Targeted at the 0.3.1 pre-release channel for live verification before any stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)